### PR TITLE
Set up tests workflow to run in both test and dev

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,12 @@ jobs:
     python-job:
         name: "PyTest tests"
         runs-on: ubuntu-latest
-        environment: "test"
+        strategy:
+          matrix:
+            include:
+              - environment: test
+              - environment: dev
+        environment: ${{ matrix.environment }}
 
         steps:
           - name: Checkout repository
@@ -37,7 +42,7 @@ jobs:
             with:
                 aws-region: us-west-2
                 role-to-assume: ${{ vars.MAAP_EOAPI_TEST_ROLE }}
-                role-session-name: maap-eoapi-test
+                role-session-name: maap-eoapi-tests-${{ matrix.environment }}
 
           - name: Install dependencies
             run: |


### PR DESCRIPTION
This PR modifies `.github/workflows/tests.yml` so that the test workflow runs automatically (and sequentially) in both the `test` and `dev` environments. Note that for now workflows need to be triggered in the GH UI (`on: workflow_dispatch`). A subsequent PR will turn on the cron schedule. 

The test workflow ran successfully with this PR.

[There is a corresponding PR that was required for this to work in maap-aws-oidc. ](https://github.com/MAAP-Project/maap-aws-oidc/pull/2)