### PR TITLE
Add delay for inserting item before querying it

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,3 +57,18 @@ jobs:
                 SECRET_ID: ${{ vars.SECRET_ID }}
             run: |
                 pytest tests
+
+          - name: Post to a Slack channel
+                id: slack
+                uses: slackapi/slack-github-action@v1.24.0
+                with:
+                  # Slack channel id, channel name, or user id to post message.
+                  # See also: https://api.slack.com/methods/chat.postMessage#channels
+                  # You can pass in multiple channels to post to by providing a comma-delimited list of channel IDs.
+                  channel-id: 'C05JV1UKJ2V'
+                  # For posting a simple plain text message
+                  slack-message: "GitHub build result: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+                env:
+                  SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
+          

--- a/tests/test_stac_ingestion.py
+++ b/tests/test_stac_ingestion.py
@@ -53,6 +53,8 @@ def test_titiler_pgstac(stac_ingestion_instance, test_titiler_search_request, te
 # Test querying items and verifying inserted items
 def test_query_items(stac_ingestion_instance, test_collection, test_item):
     response = stac_ingestion_instance.query_items(test_collection["id"])
+    # allow for some time for the items to be inserted
+    time.sleep(10)
     assert response.status_code in [200, 201], f"Failed to query the items :\n{response.text}"
     item = response.json()["features"][0]
     assert item["id"] == test_item["id"], f"Inserted item - {test_item} \n not found in the queried items {item}"


### PR DESCRIPTION
Sometimes the tests fail as the querying of items is performed before the items are actually inserted. So, adding a delay to overcome this (similar to mosaic generation tests)