### PR TITLE
add mosaic settings and permissions to the titiler-pgstac Lambda

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up node
       uses: actions/setup-node@v2
       with:
-        node-version: 16
+        node-version: 20
 
     - name: Assume Github OIDC role
       uses: aws-actions/configure-aws-credentials@v2
@@ -58,6 +58,7 @@ jobs:
         INGESTOR_DOMAIN_NAME: ${{ vars.INGESTOR_DOMAIN_NAME }}
         TITILER_PGSTAC_API_CUSTOM_DOMAIN_NAME: ${{ vars.TITILER_PGSTAC_API_CUSTOM_DOMAIN_NAME }}
         STAC_API_CUSTOM_DOMAIN_NAME: ${{ vars.STAC_API_CUSTOM_DOMAIN_NAME}}
+        MOSAIC_HOST: ${{ vars.MOSAIC_HOST }}
       run: |
         npm install -g aws-cdk
         cdk deploy --all --require-approval never

--- a/cdk/app.ts
+++ b/cdk/app.ts
@@ -5,7 +5,7 @@ import * as cdk from "aws-cdk-lib";
 import { Vpc } from "./Vpc";
 import { Config } from "./config";
 import { PgStacInfra } from "./PgStacInfra";
-const { 
+const {
   stage,
   version,
   buildStackName,
@@ -14,6 +14,7 @@ const {
   dataAccessRoleArn,
   stacApiIntegrationApiArn,
   dbAllocatedStorage,
+  mosaicHost,
   certificateArn,
   ingestorDomainName,
   stacApiCustomDomainName,
@@ -36,17 +37,17 @@ new PgStacInfra(app, buildStackName("pgSTAC"), {
   jwksUrl,
   terminationProtection: false,
   bastionIpv4AllowList: [
-    "121.141.217.93/32", // Emile work
     "66.17.119.38/32", // Jamison
     "131.215.220.32/32", // Aimee's home
-    "104.9.124.28/32", // Sean 
-    "222.108.19.128/32", // Emile home
+    "104.9.124.28/32", // Sean
+    "75.134.157.176/32", // Henry
   ],
   bastionUserDataPath: "./userdata.yaml",
   bastionHostCreateElasticIp: stage === "prod",
   dataAccessRoleArn: dataAccessRoleArn,
   stacApiIntegrationApiArn: stacApiIntegrationApiArn,
   allocatedStorage: dbAllocatedStorage,
+  mosaicHost: mosaicHost,
   titilerBucketsPath: "./titiler_buckets.yaml",
   certificateArn: certificateArn,
   IngestorDomainName: ingestorDomainName,

--- a/cdk/config.ts
+++ b/cdk/config.ts
@@ -6,6 +6,7 @@ export class Config {
   readonly dataAccessRoleArn: string;
   readonly stacApiIntegrationApiArn: string;
   readonly dbAllocatedStorage: number;
+  readonly mosaicHost: string;
   readonly certificateArn: string | undefined;
   readonly ingestorDomainName: string | undefined;
   readonly stacApiCustomDomainName: string | undefined;
@@ -18,23 +19,29 @@ export class Config {
     this.tags = {
       project: "MAAP",
       author: String(process.env.AUTHOR),
-      gitCommit : String(process.env.COMMIT_SHA),
+      gitCommit: String(process.env.COMMIT_SHA),
       gitRepository: String(process.env.GIT_REPOSITORY),
       version: String(process.env.VERSION),
       stage: this.stage,
     };
     if (!process.env.JWKS_URL) throw Error("Must provide JWKS_URL");
     this.jwksUrl = process.env.JWKS_URL;
-    if (!process.env.DATA_ACCESS_ROLE_ARN) throw Error("Must provide DATA_ACCESS_ROLE_ARN");
+    if (!process.env.DATA_ACCESS_ROLE_ARN)
+      throw Error("Must provide DATA_ACCESS_ROLE_ARN");
     this.dataAccessRoleArn = process.env.DATA_ACCESS_ROLE_ARN!;
-    if (!process.env.STAC_API_INTEGRATION_API_ARN) throw Error("Must provide STAC_API_INTEGRATION_API_ARN");
+    if (!process.env.STAC_API_INTEGRATION_API_ARN)
+      throw Error("Must provide STAC_API_INTEGRATION_API_ARN");
     this.stacApiIntegrationApiArn = process.env.STAC_API_INTEGRATION_API_ARN!;
-    if (!process.env.DB_ALLOCATED_STORAGE) throw Error("Must provide DB_ALLOCATED_STORAGE");
+    if (!process.env.DB_ALLOCATED_STORAGE)
+      throw Error("Must provide DB_ALLOCATED_STORAGE");
     this.dbAllocatedStorage = Number(process.env.DB_ALLOCATED_STORAGE!);
+    if (!process.env.MOSAIC_HOST) throw Error("Must provide MOSAIC_HOST");
+    this.mosaicHost = process.env.MOSAIC_HOST!;
 
     this.certificateArn = process.env.CERTIFICATE_ARN;
     this.ingestorDomainName = process.env.INGESTOR_DOMAIN_NAME;
-    this.titilerPgStacApiCustomDomainName = process.env.TITILER_PGSTAC_API_CUSTOM_DOMAIN_NAME;
+    this.titilerPgStacApiCustomDomainName =
+      process.env.TITILER_PGSTAC_API_CUSTOM_DOMAIN_NAME;
     this.stacApiCustomDomainName = process.env.STAC_API_CUSTOM_DOMAIN_NAME;
   }
 


### PR DESCRIPTION
This is the first PR for adding the `/mosaicjson` endpoints to the MAAP titiler-pgstac instance. This does not add the actual functionality but adds the env vars and permissions that we need for the Lambda to access the dynamodb table. I set the deploy environment variable `MOSAIC_HOST` for `test` and `dev` already. For `dev` I set it to write to the same table as `tiler.maap-project.org`.

I ran the deployment in the `test` environment, I think everything looks right with the new `MOSAIC_HOST` and `MOSAIC_BACKEND` env vars in the Lambda and role permissions for using the dynamodb table. https://github.com/MAAP-Project/maap-eoapi/actions/runs/11459611672/job/31884484843

A good chunk of the line changes are from formatting the typescript files with `prettier`.

I saw that we were using Node 16 so I went ahead and updated that to a less deprecated version. Closes #30 