### PR TITLE
allow titiler-pgstac access to all buckets

### DIFF
--- a/titiler_buckets.yaml
+++ b/titiler_buckets.yaml
@@ -1,2 +1,2 @@
 # list of s3 buckets the titiler lambda will be granted access to
-- nasa-maap-data-store
+- '*'


### PR DESCRIPTION
This should be the last thing we need to add to this `titiler-pgstac` instance to reach feature parity with `titiler.maap-project.org`. I deployed this branch to the `test` environment and tested the `/cog/info` endpoint on `s3://maap-ops-workspace/shared/alexdevseed/landsat8/viz/Landsat8_30542_comp_cog_2015-2020_dps.tif` - it worked!