### PR TITLE
upgrade to titiler==0.18.10

### DIFF
--- a/cdk/runtimes/eoapi/raster/pyproject.toml
+++ b/cdk/runtimes/eoapi/raster/pyproject.toml
@@ -20,8 +20,8 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "titiler.pgstac==1.3.1",
-    "titiler.extensions[cogeo]==0.18.5",
-    "titiler.mosaic==0.18.5",
+    "titiler.extensions[cogeo]==0.18.10",
+    "titiler.mosaic==0.18.10",
     "titiler.pgstac==1.3.1",
     "pystac-client==0.8.4",
     "stac-pydantic==3.1.3",


### PR DESCRIPTION
This gives us the "show render parameters" and "share map" buttons in the `/cog/viewer` endpoint, which are useful for generating render extension metadata.
![image](https://github.com/user-attachments/assets/616f5f3a-28de-4304-b6aa-8e26b4db27a7)

I deployed it to the `test` env, you can test it out with this url: https://titiler-pgstac.dit.maap-project.org/cog/viewer?url=https://opendata.digitalglobe.com/events/mauritius-oil-spill/post-event/2020-08-12/105001001F1B5B00/105001001F1B5B00.tif