### PR TITLE
feat: add STAC Browser construct

### DIFF
--- a/cdk/PgStacInfra.ts
+++ b/cdk/PgStacInfra.ts
@@ -221,7 +221,7 @@ export class PgStacInfra extends Stack {
 
     new StacBrowser(this, "stac-browser", {
       bucketArn: stacBrowserBucket.bucketArn,
-      stacCatalogUrl: stage === "test" ? "https://stac.dit.maap-project.org" : "https://stac.maap-project.org",
+      stacCatalogUrl: props.stacApiCustomDomainName,
       githubRepoTag: props.stacBrowserRepoTag,
       websiteIndexDocument: "index.html",
     })
@@ -333,7 +333,7 @@ export interface Props extends StackProps {
    * Domain name to use for stac api. If defined, a new CDN will be created.
    * Example: "stac-api.dit.maap-project.org""
    */
-  stacApiCustomDomainName?: string | undefined;
+  stacApiCustomDomainName: string;
 
   /**
    * Tag of the stac-browser repo from https://github.com/radiantearth/stac-browser

--- a/cdk/app.ts
+++ b/cdk/app.ts
@@ -20,7 +20,6 @@ const {
   stacApiCustomDomainName,
   titilerPgStacApiCustomDomainName,
   stacBrowserRepoTag,
-  stacBrowserDistributionArn,
 } = new Config();
 
 export const app = new cdk.App({});
@@ -56,5 +55,4 @@ new PgStacInfra(app, buildStackName("pgSTAC"), {
   stacApiCustomDomainName: stacApiCustomDomainName,
   titilerPgStacApiCustomDomainName: titilerPgStacApiCustomDomainName,
   stacBrowserRepoTag: stacBrowserRepoTag,
-  stacBrowserDistributionArn: stacBrowserDistributionArn,
 });

--- a/cdk/app.ts
+++ b/cdk/app.ts
@@ -19,6 +19,8 @@ const {
   ingestorDomainName,
   stacApiCustomDomainName,
   titilerPgStacApiCustomDomainName,
+  stacBrowserRepoTag,
+  stacBrowserDistributionArn,
 } = new Config();
 
 export const app = new cdk.App({});
@@ -53,4 +55,6 @@ new PgStacInfra(app, buildStackName("pgSTAC"), {
   IngestorDomainName: ingestorDomainName,
   stacApiCustomDomainName: stacApiCustomDomainName,
   titilerPgStacApiCustomDomainName: titilerPgStacApiCustomDomainName,
+  stacBrowserRepoTag: stacBrowserRepoTag,
+  stacBrowserDistributionArn: stacBrowserDistributionArn,
 });

--- a/cdk/config.ts
+++ b/cdk/config.ts
@@ -11,10 +11,37 @@ export class Config {
   readonly ingestorDomainName: string | undefined;
   readonly stacApiCustomDomainName: string | undefined;
   readonly titilerPgStacApiCustomDomainName: string | undefined;
+  readonly stacBrowserRepoTag: string;
+  readonly stacBrowserDistributionArn: string;
 
   constructor() {
-    if (!process.env.STAGE) throw Error("Must provide STAGE");
-    this.stage = process.env.STAGE;
+    // These are required environment variables and cannot be undefined
+    const requiredVariables = [
+      { name: 'STAGE', value: process.env.STAGE },
+      { name: 'JWKS_URL', value: process.env.JWKS_URL },
+      { name: 'DATA_ACCESS_ROLE_ARN', value: process.env.DATA_ACCESS_ROLE_ARN },
+      { name: 'STAC_API_INTEGRATION_API_ARN', value: process.env.STAC_API_INTEGRATION_API_ARN },
+      { name: 'DB_ALLOCATED_STORAGE', value: process.env.DB_ALLOCATED_STORAGE },
+      { name: 'MOSAIC_HOST', value: process.env.MOSAIC_HOST },
+      { name: 'STAC_BROWSER_REPO_TAG', value: process.env.STAC_BROWSER_REPO_TAG },
+      { name: 'STAC_BROWSER_DISTRIBUTION_ARN', value: process.env.STAC_BROWSER_DISTRIBUTION_ARN },
+    ];
+
+    for (const variable of requiredVariables) {
+      if (!variable.value) {
+      throw new Error(`Must provide ${variable.name}`);
+      }
+    }
+
+    this.stage = process.env.STAGE!;
+    this.jwksUrl = process.env.JWKS_URL!;
+    this.dataAccessRoleArn = process.env.DATA_ACCESS_ROLE_ARN!;
+    this.stacApiIntegrationApiArn = process.env.STAC_API_INTEGRATION_API_ARN!;
+    this.dbAllocatedStorage = Number(process.env.DB_ALLOCATED_STORAGE!);
+    this.mosaicHost = process.env.MOSAIC_HOST!;
+    this.stacBrowserRepoTag = process.env.STAC_BROWSER_REPO_TAG!;
+    this.stacBrowserDistributionArn = process.env.STAC_BROWSER_DISTRIBUTION_ARN!;
+
     this.version = process.env.npm_package_version!; // Set by node.js
     this.tags = {
       project: "MAAP",
@@ -24,19 +51,6 @@ export class Config {
       version: String(process.env.VERSION),
       stage: this.stage,
     };
-    if (!process.env.JWKS_URL) throw Error("Must provide JWKS_URL");
-    this.jwksUrl = process.env.JWKS_URL;
-    if (!process.env.DATA_ACCESS_ROLE_ARN)
-      throw Error("Must provide DATA_ACCESS_ROLE_ARN");
-    this.dataAccessRoleArn = process.env.DATA_ACCESS_ROLE_ARN!;
-    if (!process.env.STAC_API_INTEGRATION_API_ARN)
-      throw Error("Must provide STAC_API_INTEGRATION_API_ARN");
-    this.stacApiIntegrationApiArn = process.env.STAC_API_INTEGRATION_API_ARN!;
-    if (!process.env.DB_ALLOCATED_STORAGE)
-      throw Error("Must provide DB_ALLOCATED_STORAGE");
-    this.dbAllocatedStorage = Number(process.env.DB_ALLOCATED_STORAGE!);
-    if (!process.env.MOSAIC_HOST) throw Error("Must provide MOSAIC_HOST");
-    this.mosaicHost = process.env.MOSAIC_HOST!;
 
     this.certificateArn = process.env.CERTIFICATE_ARN;
     this.ingestorDomainName = process.env.INGESTOR_DOMAIN_NAME;

--- a/cdk/config.ts
+++ b/cdk/config.ts
@@ -9,7 +9,7 @@ export class Config {
   readonly mosaicHost: string;
   readonly certificateArn: string | undefined;
   readonly ingestorDomainName: string | undefined;
-  readonly stacApiCustomDomainName: string | undefined;
+  readonly stacApiCustomDomainName: string;
   readonly titilerPgStacApiCustomDomainName: string | undefined;
   readonly stacBrowserRepoTag: string;
 
@@ -23,6 +23,7 @@ export class Config {
       { name: 'DB_ALLOCATED_STORAGE', value: process.env.DB_ALLOCATED_STORAGE },
       { name: 'MOSAIC_HOST', value: process.env.MOSAIC_HOST },
       { name: 'STAC_BROWSER_REPO_TAG', value: process.env.STAC_BROWSER_REPO_TAG },
+      { name: 'STAC_API_CUSTOM_DOMAIN_NAME', value: process.env.STAC_API_CUSTOM_DOMAIN_NAME },
     ];
 
     for (const variable of requiredVariables) {
@@ -38,6 +39,7 @@ export class Config {
     this.dbAllocatedStorage = Number(process.env.DB_ALLOCATED_STORAGE!);
     this.mosaicHost = process.env.MOSAIC_HOST!;
     this.stacBrowserRepoTag = process.env.STAC_BROWSER_REPO_TAG!;
+    this.stacApiCustomDomainName = process.env.STAC_API_CUSTOM_DOMAIN_NAME!;
 
     this.version = process.env.npm_package_version!; // Set by node.js
     this.tags = {
@@ -53,7 +55,6 @@ export class Config {
     this.ingestorDomainName = process.env.INGESTOR_DOMAIN_NAME;
     this.titilerPgStacApiCustomDomainName =
       process.env.TITILER_PGSTAC_API_CUSTOM_DOMAIN_NAME;
-    this.stacApiCustomDomainName = process.env.STAC_API_CUSTOM_DOMAIN_NAME;
   }
 
   /**

--- a/cdk/config.ts
+++ b/cdk/config.ts
@@ -12,7 +12,6 @@ export class Config {
   readonly stacApiCustomDomainName: string | undefined;
   readonly titilerPgStacApiCustomDomainName: string | undefined;
   readonly stacBrowserRepoTag: string;
-  readonly stacBrowserDistributionArn: string;
 
   constructor() {
     // These are required environment variables and cannot be undefined
@@ -24,7 +23,6 @@ export class Config {
       { name: 'DB_ALLOCATED_STORAGE', value: process.env.DB_ALLOCATED_STORAGE },
       { name: 'MOSAIC_HOST', value: process.env.MOSAIC_HOST },
       { name: 'STAC_BROWSER_REPO_TAG', value: process.env.STAC_BROWSER_REPO_TAG },
-      { name: 'STAC_BROWSER_DISTRIBUTION_ARN', value: process.env.STAC_BROWSER_DISTRIBUTION_ARN },
     ];
 
     for (const variable of requiredVariables) {
@@ -40,7 +38,6 @@ export class Config {
     this.dbAllocatedStorage = Number(process.env.DB_ALLOCATED_STORAGE!);
     this.mosaicHost = process.env.MOSAIC_HOST!;
     this.stacBrowserRepoTag = process.env.STAC_BROWSER_REPO_TAG!;
-    this.stacBrowserDistributionArn = process.env.STAC_BROWSER_DISTRIBUTION_ARN!;
 
     this.version = process.env.npm_package_version!; // Set by node.js
     this.tags = {

--- a/cdk/dockerfiles/Dockerfile.raster
+++ b/cdk/dockerfiles/Dockerfile.raster
@@ -1,6 +1,6 @@
 ARG PYTHON_VERSION=3.11
 
-FROM public.ecr.aws/lambda/python:${PYTHON_VERSION}
+FROM --platform=linux/amd64 public.ecr.aws/lambda/python:${PYTHON_VERSION}
 
 # Install system dependencies to compile (numexpr)
 RUN yum install -y gcc-c++

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,10 @@
       "name": "ts_app",
       "version": "0.1.0",
       "dependencies": {
-        "aws-cdk-lib": "^2.45.0",
-        "constructs": "^10.1.113",
+        "@aws-cdk/aws-apigatewayv2-alpha": "2.114.1-alpha.0",
+        "@aws-cdk/aws-apigatewayv2-integrations-alpha": "2.114.1-alpha.0",
+        "aws-cdk-lib": "^2.130.0",
+        "constructs": "^10.3.0",
         "eoapi-cdk": "7.2.1",
         "source-map-support": "^0.5.16"
       },
@@ -42,20 +44,22 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.202",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.202.tgz",
-      "integrity": "sha512-JqlF0D4+EVugnG5dAsNZMqhu3HW7ehOXm5SDMxMbXNDMdsF0pxtQKNHRl52z1U9igsHmaFpUgSGjbhAJ+0JONg==",
+      "version": "2.2.210",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.210.tgz",
+      "integrity": "sha512-yxuGP52ZtdAGkcAik5mW79FKKv6yvc5QuCZbsKMyICk48alqs+ni7Iv2UnuGLkVSLh09+ixoHHu4o5rIv8X9jg==",
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/asset-kubectl-v20": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.2.tgz",
-      "integrity": "sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.3.tgz",
+      "integrity": "sha512-cDG1w3ieM6eOT9mTefRuTypk95+oyD7P5X/wRltwmYxU7nZc3+076YEVS6vrjDKr3ADYbfn0lDKpfB1FBtO9CQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.1.tgz",
-      "integrity": "sha512-DDt4SLdLOwWCjGtltH4VCST7hpOI5DzieuhGZsBpZ+AgJdSI2GCjklCXm0GCTwJG/SolkL5dtQXyUKgg9luBDg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.0.tgz",
+      "integrity": "sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A==",
+      "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/aws-apigatewayv2-alpha": {
       "version": "2.114.1-alpha.0",

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
     "typescript": "~3.9.7"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.45.0",
+    "aws-cdk-lib": "^2.130.0",
     "eoapi-cdk": "7.2.1",
-    "constructs": "^10.1.113",
+    "constructs": "^10.3.0",
     "source-map-support": "^0.5.16"
   }
 }


### PR DESCRIPTION
## Description
I've added `STAC_BROWSER_REPO_TAG` to the repositories environment variables
- Adds STAC Browser eoapi construct
- Bumps libraries to align with eoapi-cdk's
- Adds platform to titiler dockerfile
- Changes multiple `if` statement checks to iterate checks over mandatory environment variables

Note: aws-cdk-lib version 2.130 does not support OAC for cloudfront distributions, eoapi-cdk would need to be bumped to latest aws-cdk-lib versions to comply with MCP security constraints