### PR TITLE
fix: cloudfront distro, added logging

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,6 +60,7 @@ jobs:
         STAC_API_CUSTOM_DOMAIN_NAME: ${{ vars.STAC_API_CUSTOM_DOMAIN_NAME}}
         MOSAIC_HOST: ${{ vars.MOSAIC_HOST }}
         STAC_BROWSER_REPO_TAG: ${{ vars.STAC_BROWSER_REPO_TAG }}
+        STAC_BROWSER_CUSTOM_DOMAIN_NAME: ${{ vars.STAC_BROWSER_CUSTOM_DOMAIN_NAME }}
       run: |
         npm install -g aws-cdk
         cdk deploy --all --require-approval never

--- a/cdk/app.ts
+++ b/cdk/app.ts
@@ -20,6 +20,7 @@ const {
   stacApiCustomDomainName,
   titilerPgStacApiCustomDomainName,
   stacBrowserRepoTag,
+  stacBrowserCustomDomainName,
 } = new Config();
 
 export const app = new cdk.App({});
@@ -55,4 +56,5 @@ new PgStacInfra(app, buildStackName("pgSTAC"), {
   stacApiCustomDomainName: stacApiCustomDomainName,
   titilerPgStacApiCustomDomainName: titilerPgStacApiCustomDomainName,
   stacBrowserRepoTag: stacBrowserRepoTag,
+  stacBrowserCustomDomainName: stacBrowserCustomDomainName,
 });

--- a/cdk/config.ts
+++ b/cdk/config.ts
@@ -12,6 +12,7 @@ export class Config {
   readonly stacApiCustomDomainName: string;
   readonly titilerPgStacApiCustomDomainName: string | undefined;
   readonly stacBrowserRepoTag: string;
+  readonly stacBrowserCustomDomainName: string;
 
   constructor() {
     // These are required environment variables and cannot be undefined
@@ -23,6 +24,7 @@ export class Config {
       { name: 'DB_ALLOCATED_STORAGE', value: process.env.DB_ALLOCATED_STORAGE },
       { name: 'MOSAIC_HOST', value: process.env.MOSAIC_HOST },
       { name: 'STAC_BROWSER_REPO_TAG', value: process.env.STAC_BROWSER_REPO_TAG },
+      { name: 'STAC_BROWSER_CUSTOM_DOMAIN_NAME', value: process.env.STAC_BROWSER_CUSTOM_DOMAIN_NAME },
       { name: 'STAC_API_CUSTOM_DOMAIN_NAME', value: process.env.STAC_API_CUSTOM_DOMAIN_NAME },
     ];
 
@@ -39,6 +41,7 @@ export class Config {
     this.dbAllocatedStorage = Number(process.env.DB_ALLOCATED_STORAGE!);
     this.mosaicHost = process.env.MOSAIC_HOST!;
     this.stacBrowserRepoTag = process.env.STAC_BROWSER_REPO_TAG!;
+    this.stacBrowserCustomDomainName = process.env.STAC_BROWSER_CUSTOM_DOMAIN_NAME!;
     this.stacApiCustomDomainName = process.env.STAC_API_CUSTOM_DOMAIN_NAME!;
 
     this.version = process.env.npm_package_version!; // Set by node.js


### PR DESCRIPTION
## Description
Fixes to cloudfront distro
- added alternate domain name (STAC Browser Custom Domain Name Var)
- set default root object
- added certificate from props, shared with other CDN
- added logging bucket, logging prefix