### PR TITLE
fix: resolved circular dependency issue

### DIFF
--- a/cdk/PgStacInfra.ts
+++ b/cdk/PgStacInfra.ts
@@ -243,7 +243,8 @@ export class PgStacInfra extends Stack {
     
     new StacBrowser(this, "stac-browser", {
       bucketArn: stacBrowserBucket.bucketArn,
-      stacCatalogUrl: `https://${props.stacApiCustomDomainName}/`,
+      stacCatalogUrl: props.stacApiCustomDomainName.startsWith('https://') ? 
+        props.stacApiCustomDomainName : `https://${props.stacApiCustomDomainName}/`,
       githubRepoTag: props.stacBrowserRepoTag,
       websiteIndexDocument: "index.html",
     });


### PR DESCRIPTION
## Description
A couple of final changes
- Removed tags, was causing a circular dependency
- Logging bucket access control swapped from PRIVATE to LOG_DELIVERY_WRITE
- stacCatalogUrl for STAC Browser construct must be formatted like `https://{stac_catalog_url}/`
- Bucket policy to allow Cloudfront to put access logs