### PR TITLE
add ec2 instance with pgbouncer

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,6 +51,7 @@ jobs:
         JWKS_URL: ${{ steps.import-stacks-vars-to-output.outputs.JWKS_URL }}
         DATA_ACCESS_ROLE_ARN: ${{ steps.import-stacks-vars-to-output.outputs.DATA_ACCESS_ROLE_ARN }}
         DB_ALLOCATED_STORAGE: ${{ vars.DB_ALLOCATED_STORAGE }}
+        DB_INSTANCE_TYPE: ${{ vars.DB_INSTANCE_TYPE }}
         GIT_REPOSITORY: ${{ github.repository}}
         COMMIT_SHA: ${{ github.sha }}
         AUTHOR: ${{ github.actor }}

--- a/cdk/PgBouncer.ts
+++ b/cdk/PgBouncer.ts
@@ -79,13 +79,13 @@ export class PgBouncer extends Construct {
       ),
       pgBouncerConfig = {
         poolMode: "transaction",
-        maxClientConn: 1000,
-        defaultPoolSize: 20,
-        minPoolSize: 10,
+        maxClientConn: 200,
+        defaultPoolSize: 5,
+        minPoolSize: 0,
         reservePoolSize: 5,
         reservePoolTimeout: 5,
-        maxDbConnections: 50,
-        maxUserConnections: 50,
+        maxDbConnections: 40,
+        maxUserConnections: 40,
       },
     } = props;
 

--- a/cdk/PgBouncer.ts
+++ b/cdk/PgBouncer.ts
@@ -194,7 +194,7 @@ export class PgBouncer extends Construct {
       'echo "\\"$DB_USER\\" \\"$DB_PASSWORD\\"" > /etc/pgbouncer/userlist.txt',
 
       "# Set correct permissions",
-      "chown pgbouncer:pgbouncer /etc/pgbouncer/pgbouncer.ini /etc/pgbouncer/userlist.txt",
+      "chown postgres:postgres /etc/pgbouncer/pgbouncer.ini /etc/pgbouncer/userlist.txt",
       "chmod 600 /etc/pgbouncer/pgbouncer.ini /etc/pgbouncer/userlist.txt",
 
       "# Restart pgbouncer",

--- a/cdk/PgBouncer.ts
+++ b/cdk/PgBouncer.ts
@@ -187,12 +187,9 @@ export class PgBouncer extends Construct {
       "chown postgres:postgres /etc/pgbouncer/pgbouncer.ini /etc/pgbouncer/userlist.txt",
       "chmod 600 /etc/pgbouncer/pgbouncer.ini /etc/pgbouncer/userlist.txt",
 
-      "# Restart pgbouncer",
-      "systemctl restart pgbouncer",
-
       // Enable and start pgbouncer service
       "systemctl enable pgbouncer",
-      "systemctl start pgbouncer",
+      "systemctl restart pgbouncer",
 
       // Health check
       "# Create health check script",

--- a/cdk/PgBouncer.ts
+++ b/cdk/PgBouncer.ts
@@ -151,7 +151,6 @@ export class PgBouncer extends Construct {
       "DEBIAN_FRONTEND=noninteractive apt-get install -y pgbouncer jq awscli",
 
       // Create update script
-      "cat <<'EOF' > /usr/local/bin/update-pgbouncer-config.sh",
       "#!/bin/bash",
       "set -euxo pipefail",
 
@@ -199,11 +198,6 @@ export class PgBouncer extends Construct {
 
       "# Restart pgbouncer",
       "systemctl restart pgbouncer",
-      "EOF",
-
-      // Make script executable and run it
-      "chmod +x /usr/local/bin/update-pgbouncer-config.sh",
-      "/usr/local/bin/update-pgbouncer-config.sh",
 
       // Enable and start pgbouncer service
       "systemctl enable pgbouncer",

--- a/cdk/PgBouncer.ts
+++ b/cdk/PgBouncer.ts
@@ -9,6 +9,8 @@ import { Construct } from "constructs";
 import * as fs from "fs";
 import * as path from "path";
 
+// used to populate pgbouncer config:
+// see https://www.pgbouncer.org/config.html for details
 export interface PgBouncerConfigProps {
   poolMode?: "transaction" | "session" | "statement";
   maxClientConn?: number;
@@ -97,6 +99,8 @@ export class PgBouncer extends Construct {
     // calculate approximate max_connections setting for this RDS instance type
     const maxConnections = this.calculateMaxConnections(dbInstanceType);
 
+    // maxDbConnections (and maxUserConnections) are the only settings that need
+    // to be responsive to the database size/max_connections setting
     return {
       poolMode: "transaction",
       maxClientConn: 1000,

--- a/cdk/PgBouncer.ts
+++ b/cdk/PgBouncer.ts
@@ -29,11 +29,6 @@ export interface PgBouncerProps {
   };
 
   /**
-   * Security groups that need access to PgBouncer
-   */
-  clientSecurityGroups: ec2.ISecurityGroup[];
-
-  /**
    * Whether to deploy in public subnet
    * @default false
    */
@@ -71,7 +66,6 @@ export class PgBouncer extends Construct {
     const {
       vpc,
       database,
-      clientSecurityGroups,
       usePublicSubnet = false,
       instanceType = ec2.InstanceType.of(
         ec2.InstanceClass.T3,
@@ -94,15 +88,6 @@ export class PgBouncer extends Construct {
       vpc,
       description: "Security group for PgBouncer instance",
       allowAllOutbound: true,
-    });
-
-    // Allow incoming PostgreSQL traffic from client security groups
-    clientSecurityGroups.forEach((clientSg, index) => {
-      this.securityGroup.addIngressRule(
-        clientSg,
-        ec2.Port.tcp(5432),
-        `Allow PostgreSQL access from client security group ${index + 1}`,
-      );
     });
 
     // Allow PgBouncer to connect to RDS

--- a/cdk/PgBouncer.ts
+++ b/cdk/PgBouncer.ts
@@ -1,0 +1,203 @@
+import {
+  aws_ec2 as ec2,
+  aws_iam as iam,
+  aws_secretsmanager as secretsmanager,
+  Stack,
+} from "aws-cdk-lib";
+import { Construct } from "constructs";
+
+export interface PgBouncerProps {
+  /**
+   * VPC to deploy PgBouncer into
+   */
+  vpc: ec2.IVpc;
+
+  /**
+   * The RDS instance to connect to
+   */
+  database: {
+    connections: ec2.Connections;
+    secret: secretsmanager.ISecret;
+  };
+
+  /**
+   * Security groups that need access to PgBouncer
+   */
+  clientSecurityGroups: ec2.ISecurityGroup[];
+
+  /**
+   * Whether to deploy in public subnet
+   * @default false
+   */
+  usePublicSubnet?: boolean;
+
+  /**
+   * Instance type for PgBouncer
+   * @default t3.small
+   */
+  instanceType?: ec2.InstanceType;
+
+  /**
+   * PgBouncer configuration options
+   */
+  pgBouncerConfig?: {
+    poolMode?: "transaction" | "session" | "statement";
+    maxClientConn?: number;
+    defaultPoolSize?: number;
+    minPoolSize?: number;
+    reservePoolSize?: number;
+    reservePoolTimeout?: number;
+    maxDbConnections?: number;
+    maxUserConnections?: number;
+  };
+}
+
+export class PgBouncer extends Construct {
+  public readonly securityGroup: ec2.ISecurityGroup;
+  public readonly instance: ec2.Instance;
+  public readonly endpoint: string;
+
+  constructor(scope: Construct, id: string, props: PgBouncerProps) {
+    super(scope, id);
+
+    const {
+      vpc,
+      database,
+      clientSecurityGroups,
+      usePublicSubnet = false,
+      instanceType = ec2.InstanceType.of(
+        ec2.InstanceClass.T3,
+        ec2.InstanceSize.SMALL,
+      ),
+      pgBouncerConfig = {
+        poolMode: "transaction",
+        maxClientConn: 1000,
+        defaultPoolSize: 20,
+        minPoolSize: 10,
+        reservePoolSize: 5,
+        reservePoolTimeout: 5,
+        maxDbConnections: 50,
+        maxUserConnections: 50,
+      },
+    } = props;
+
+    // Create security group for PgBouncer
+    this.securityGroup = new ec2.SecurityGroup(this, "SecurityGroup", {
+      vpc,
+      description: "Security group for PgBouncer instance",
+      allowAllOutbound: true,
+    });
+
+    // Allow incoming PostgreSQL traffic from client security groups
+    clientSecurityGroups.forEach((clientSg, index) => {
+      this.securityGroup.addIngressRule(
+        clientSg,
+        ec2.Port.tcp(5432),
+        `Allow PostgreSQL access from client security group ${index + 1}`,
+      );
+    });
+
+    // Allow PgBouncer to connect to RDS
+    database.connections.allowFrom(
+      this.securityGroup,
+      ec2.Port.tcp(5432),
+      "Allow PgBouncer to connect to RDS",
+    );
+
+    // Create role for PgBouncer instance
+    const role = new iam.Role(this, "InstanceRole", {
+      assumedBy: new iam.ServicePrincipal("ec2.amazonaws.com"),
+      managedPolicies: [
+        iam.ManagedPolicy.fromAwsManagedPolicyName(
+          "AmazonSSMManagedInstanceCore",
+        ),
+      ],
+    });
+
+    // Add policy to allow reading RDS credentials from Secrets Manager
+    role.addToPolicy(
+      new iam.PolicyStatement({
+        actions: ["secretsmanager:GetSecretValue"],
+        resources: [database.secret.secretArn],
+      }),
+    );
+
+    // Create PgBouncer instance
+    this.instance = new ec2.Instance(this, "Instance", {
+      vpc,
+      vpcSubnets: {
+        subnetType: usePublicSubnet
+          ? ec2.SubnetType.PUBLIC
+          : ec2.SubnetType.PRIVATE_WITH_EGRESS,
+      },
+      instanceType,
+      machineImage: new ec2.AmazonLinuxImage({
+        generation: ec2.AmazonLinuxGeneration.AMAZON_LINUX_2,
+      }),
+      securityGroup: this.securityGroup,
+      role,
+    });
+
+    // Create user data script
+    const userDataScript = ec2.UserData.forLinux();
+    userDataScript.addCommands(
+      "yum update -y",
+      "yum install -y pgbouncer jq aws-cli",
+      // Create configuration update script
+      `cat <<EOF > /usr/local/bin/update-pgbouncer-config.sh
+#!/bin/bash
+SECRET_ARN="${database.secret.secretArn}"
+REGION="${Stack.of(this).region}"
+
+# Fetch secret
+SECRET=\$(aws secretsmanager get-secret-value --secret-id \$SECRET_ARN --region \$REGION --query SecretString --output text)
+
+# Parse values
+DB_HOST=\$(echo \$SECRET | jq -r '.host')
+DB_PORT=\$(echo \$SECRET | jq -r '.port')
+DB_NAME=\$(echo \$SECRET | jq -r '.dbname')
+DB_USER=\$(echo \$SECRET | jq -r '.username')
+DB_PASSWORD=\$(echo \$SECRET | jq -r '.password')
+
+# Create pgbouncer config
+cat <<EOC > /etc/pgbouncer/pgbouncer.ini
+[databases]
+* = host=\$DB_HOST port=\$DB_PORT dbname=\$DB_NAME
+
+[pgbouncer]
+listen_addr = *
+listen_port = 5432
+auth_type = md5
+auth_file = /etc/pgbouncer/userlist.txt
+pool_mode = ${pgBouncerConfig.poolMode}
+max_client_conn = ${pgBouncerConfig.maxClientConn}
+default_pool_size = ${pgBouncerConfig.defaultPoolSize}
+min_pool_size = ${pgBouncerConfig.minPoolSize}
+reserve_pool_size = ${pgBouncerConfig.reservePoolSize}
+reserve_pool_timeout = ${pgBouncerConfig.reservePoolTimeout}
+max_db_connections = ${pgBouncerConfig.maxDbConnections}
+max_user_connections = ${pgBouncerConfig.maxUserConnections}
+EOC
+
+# Create auth file
+echo "\\"$DB_USER\\" \\"$DB_PASSWORD\\"" > /etc/pgbouncer/userlist.txt
+
+# Set permissions
+chown pgbouncer:pgbouncer /etc/pgbouncer/pgbouncer.ini /etc/pgbouncer/userlist.txt
+chmod 600 /etc/pgbouncer/pgbouncer.ini /etc/pgbouncer/userlist.txt
+
+# Restart pgbouncer
+systemctl restart pgbouncer
+EOF`,
+      "chmod +x /usr/local/bin/update-pgbouncer-config.sh",
+      "/usr/local/bin/update-pgbouncer-config.sh",
+      "systemctl enable pgbouncer",
+      "systemctl start pgbouncer",
+    );
+
+    this.instance.addUserData(userDataScript.render());
+
+    // Set the endpoint
+    this.endpoint = this.instance.instancePrivateIp;
+  }
+}

--- a/cdk/PgBouncer.ts
+++ b/cdk/PgBouncer.ts
@@ -75,7 +75,7 @@ export class PgBouncer extends Construct {
       usePublicSubnet = false,
       instanceType = ec2.InstanceType.of(
         ec2.InstanceClass.T3,
-        ec2.InstanceSize.NANO,
+        ec2.InstanceSize.MICRO,
       ),
       pgBouncerConfig = {
         poolMode: "transaction",

--- a/cdk/PgBouncer.ts
+++ b/cdk/PgBouncer.ts
@@ -175,7 +175,7 @@ export class PgBouncer extends Construct {
       "* = host=$DB_HOST port=$DB_PORT dbname=$DB_NAME",
       "",
       "[pgbouncer]",
-      "listen_addr = '*'",
+      "listen_addr = 0.0.0.0",
       "listen_port = 5432",
       "auth_type = md5",
       "auth_file = /etc/pgbouncer/userlist.txt",
@@ -187,6 +187,7 @@ export class PgBouncer extends Construct {
       `reserve_pool_timeout = ${pgBouncerConfig.reservePoolTimeout}`,
       `max_db_connections = ${pgBouncerConfig.maxDbConnections}`,
       `max_user_connections = ${pgBouncerConfig.maxUserConnections}`,
+      "ignore_startup_parameters = application_name,search_path",
       "EOC",
 
       "# Create userlist.txt",

--- a/cdk/PgStacInfra.ts
+++ b/cdk/PgStacInfra.ts
@@ -190,7 +190,8 @@ export class PgStacInfra extends Stack {
         .securityGroupId,
     );
 
-    const pgBouncer = new PgBouncer(this, "PgBouncer", {
+    const pgBouncer = new PgBouncer(this, "pgbouncer", {
+      instanceName: `pgbouncer-${stage}`,
       vpc: props.vpc,
       database: {
         connections: db.connections,

--- a/cdk/PgStacInfra.ts
+++ b/cdk/PgStacInfra.ts
@@ -199,7 +199,7 @@ export class PgStacInfra extends Stack {
       clientSecurityGroups: [titilerLambdaSecurityGroup],
       usePublicSubnet: props.dbSubnetPublic,
       pgBouncerConfig: {
-        poolMode: "transaction",
+        poolMode: "session",
         maxClientConn: 1000,
         defaultPoolSize: 20,
         minPoolSize: 10,

--- a/cdk/PgStacInfra.ts
+++ b/cdk/PgStacInfra.ts
@@ -200,7 +200,7 @@ export class PgStacInfra extends Stack {
       clientSecurityGroups: [titilerLambdaSecurityGroup],
       usePublicSubnet: props.dbSubnetPublic,
       pgBouncerConfig: {
-        poolMode: "session",
+        poolMode: "transaction",
         maxClientConn: 1000,
         defaultPoolSize: 20,
         minPoolSize: 10,

--- a/cdk/PgStacInfra.ts
+++ b/cdk/PgStacInfra.ts
@@ -41,6 +41,7 @@ export class PgStacInfra extends Stack {
       vpc,
       stage,
       version,
+      dbInstanceType,
       jwksUrl,
       dataAccessRoleArn,
       allocatedStorage,
@@ -63,12 +64,6 @@ export class PgStacInfra extends Stack {
     });
 
     // Pgstac Database
-    // set instance type to t3.micro if stage is test, otherwise t3.small
-    const dbInstanceType =
-      stage === "test"
-        ? ec2.InstanceType.of(ec2.InstanceClass.T3, ec2.InstanceSize.MICRO)
-        : ec2.InstanceType.of(ec2.InstanceClass.T3, ec2.InstanceSize.SMALL);
-
     const { db, pgstacSecret } = new PgStacDatabase(this, "pgstac-db", {
       vpc,
       allowMajorVersionUpgrade: true,

--- a/cdk/app.ts
+++ b/cdk/app.ts
@@ -8,6 +8,7 @@ import { PgStacInfra } from "./PgStacInfra";
 const {
   stage,
   version,
+  dbInstanceType,
   buildStackName,
   tags,
   jwksUrl,
@@ -21,7 +22,7 @@ const {
   titilerPgStacApiCustomDomainName,
   stacBrowserRepoTag,
   stacBrowserCustomDomainName,
-  stacBrowserCertificateArn
+  stacBrowserCertificateArn,
 } = new Config();
 
 export const app = new cdk.App({});
@@ -38,6 +39,7 @@ new PgStacInfra(app, buildStackName("pgSTAC"), {
   stage,
   version,
   jwksUrl,
+  dbInstanceType,
   terminationProtection: false,
   bastionIpv4AllowList: [
     "66.17.119.38/32", // Jamison

--- a/cdk/config.ts
+++ b/cdk/config.ts
@@ -1,6 +1,9 @@
+import * as aws_ec2 from "aws-cdk-lib/aws-ec2";
+
 export class Config {
   readonly stage: string;
   readonly version: string;
+  readonly dbInstanceType: aws_ec2.InstanceType;
   readonly tags: Record<string, string>;
   readonly jwksUrl: string;
   readonly dataAccessRoleArn: string;
@@ -18,32 +21,61 @@ export class Config {
   constructor() {
     // These are required environment variables and cannot be undefined
     const requiredVariables = [
-      { name: 'STAGE', value: process.env.STAGE },
-      { name: 'JWKS_URL', value: process.env.JWKS_URL },
-      { name: 'DATA_ACCESS_ROLE_ARN', value: process.env.DATA_ACCESS_ROLE_ARN },
-      { name: 'STAC_API_INTEGRATION_API_ARN', value: process.env.STAC_API_INTEGRATION_API_ARN },
-      { name: 'DB_ALLOCATED_STORAGE', value: process.env.DB_ALLOCATED_STORAGE },
-      { name: 'MOSAIC_HOST', value: process.env.MOSAIC_HOST },
-      { name: 'STAC_BROWSER_REPO_TAG', value: process.env.STAC_BROWSER_REPO_TAG },
-      { name: 'STAC_BROWSER_CUSTOM_DOMAIN_NAME', value: process.env.STAC_BROWSER_CUSTOM_DOMAIN_NAME },
-      { name: 'STAC_BROWSER_CERTIFICATE_ARN', value: process.env.STAC_BROWSER_CERTIFICATE_ARN },
-      { name: 'STAC_API_CUSTOM_DOMAIN_NAME', value: process.env.STAC_API_CUSTOM_DOMAIN_NAME },
+      { name: "STAGE", value: process.env.STAGE },
+      { name: "DB_INSTANCE_TYPE", value: process.env.DB_INSTANCE_TYPE },
+      { name: "JWKS_URL", value: process.env.JWKS_URL },
+      { name: "DATA_ACCESS_ROLE_ARN", value: process.env.DATA_ACCESS_ROLE_ARN },
+      {
+        name: "STAC_API_INTEGRATION_API_ARN",
+        value: process.env.STAC_API_INTEGRATION_API_ARN,
+      },
+      { name: "DB_ALLOCATED_STORAGE", value: process.env.DB_ALLOCATED_STORAGE },
+      { name: "MOSAIC_HOST", value: process.env.MOSAIC_HOST },
+      {
+        name: "STAC_BROWSER_REPO_TAG",
+        value: process.env.STAC_BROWSER_REPO_TAG,
+      },
+      {
+        name: "STAC_BROWSER_CUSTOM_DOMAIN_NAME",
+        value: process.env.STAC_BROWSER_CUSTOM_DOMAIN_NAME,
+      },
+      {
+        name: "STAC_BROWSER_CERTIFICATE_ARN",
+        value: process.env.STAC_BROWSER_CERTIFICATE_ARN,
+      },
+      {
+        name: "STAC_API_CUSTOM_DOMAIN_NAME",
+        value: process.env.STAC_API_CUSTOM_DOMAIN_NAME,
+      },
     ];
 
     for (const variable of requiredVariables) {
       if (!variable.value) {
-      throw new Error(`Must provide ${variable.name}`);
+        throw new Error(`Must provide ${variable.name}`);
       }
     }
 
     this.stage = process.env.STAGE!;
+
     this.jwksUrl = process.env.JWKS_URL!;
     this.dataAccessRoleArn = process.env.DATA_ACCESS_ROLE_ARN!;
     this.stacApiIntegrationApiArn = process.env.STAC_API_INTEGRATION_API_ARN!;
+
+    try {
+      this.dbInstanceType = new aws_ec2.InstanceType(
+        process.env.DB_INSTANCE_TYPE!,
+      );
+    } catch (error) {
+      throw new Error(
+        `Invalid DB_INSTANCE_TYPE: ${process.env.DB_INSTANCE_TYPE!}. Error: ${error}`,
+      );
+    }
+
     this.dbAllocatedStorage = Number(process.env.DB_ALLOCATED_STORAGE!);
     this.mosaicHost = process.env.MOSAIC_HOST!;
     this.stacBrowserRepoTag = process.env.STAC_BROWSER_REPO_TAG!;
-    this.stacBrowserCustomDomainName = process.env.STAC_BROWSER_CUSTOM_DOMAIN_NAME!;
+    this.stacBrowserCustomDomainName =
+      process.env.STAC_BROWSER_CUSTOM_DOMAIN_NAME!;
     this.stacBrowserCertificateArn = process.env.STAC_BROWSER_CERTIFICATE_ARN!;
     this.stacApiCustomDomainName = process.env.STAC_API_CUSTOM_DOMAIN_NAME!;
 

--- a/cdk/handlers/raster_handler.py
+++ b/cdk/handlers/raster_handler.py
@@ -8,11 +8,12 @@ from eoapi.raster.utils import get_secret_dict
 
 # Update postgres env variables before importing titiler.pgstac.main
 pgstac_secret_arn = os.environ["PGSTAC_SECRET_ARN"]
+pgbouncer_host = os.getenv("PGBOUNCER_HOST")
 
 secret = get_secret_dict(pgstac_secret_arn)
 os.environ.update(
     {
-        "postgres_host": secret["host"],
+        "postgres_host": pgbouncer_host or secret["host"],
         "postgres_dbname": secret["dbname"],
         "postgres_user": secret["username"],
         "postgres_pass": secret["password"],
@@ -20,10 +21,9 @@ os.environ.update(
     }
 )
 
+from eoapi.raster.main import app
 from mangum import Mangum
 from titiler.pgstac.db import connect_to_db
-
-from eoapi.raster.main import app
 
 logging.getLogger("mangum.lifespan").setLevel(logging.ERROR)
 logging.getLogger("mangum.http").setLevel(logging.ERROR)

--- a/cdk/scripts/pgbouncer-setup.sh
+++ b/cdk/scripts/pgbouncer-setup.sh
@@ -20,7 +20,15 @@ sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)
 
 # Install required packages
 apt-get update
-sleep 5
+
+wait_for_dpkg_lock() {
+  while fuser /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock >/dev/null 2>&1; do
+    echo "Waiting for dpkg lock to be released..."
+    sleep 2
+  done
+}
+
+wait_for_dpkg_lock
 DEBIAN_FRONTEND=noninteractive apt-get install -y pgbouncer jq awscli
 
 echo "Fetching secret from ARN: ${SECRET_ARN}"

--- a/cdk/scripts/pgbouncer-setup.sh
+++ b/cdk/scripts/pgbouncer-setup.sh
@@ -166,7 +166,7 @@ chmod +x /var/lib/cloud/scripts/per-boot/00-run-config.sh
 mkdir -p /opt/pgbouncer/cloudwatch
 
 # Install CloudWatch agent
-if ! wget https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb; then
+if ! wget -q https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb; then
     echo 'Failed to download CloudWatch agent' | logger -t pgbouncer-setup
     exit 1
 fi

--- a/cdk/scripts/pgbouncer-setup.sh
+++ b/cdk/scripts/pgbouncer-setup.sh
@@ -57,7 +57,7 @@ max_db_connections = ${MAX_DB_CONNECTIONS}
 max_user_connections = ${MAX_USER_CONNECTIONS}
 ignore_startup_parameters = application_name,search_path
 logfile = /var/log/pgbouncer/pgbouncer.log
-pid_file = /var/run/pgbouncer/pgbouncer.pid
+pidfile = /var/run/pgbouncer/pgbouncer.pid
 admin_users = $DB_USER
 stats_users = $DB_USER
 log_connections = 1
@@ -79,14 +79,19 @@ set -x
 chown postgres:postgres /etc/pgbouncer/pgbouncer.ini /etc/pgbouncer/userlist.txt
 chmod 600 /etc/pgbouncer/pgbouncer.ini /etc/pgbouncer/userlist.txt
 
-# Enable and start pgbouncer service
-systemctl enable pgbouncer
-systemctl restart pgbouncer
-
 # Configure logging
 mkdir -p /var/log/pgbouncer /var/run/pgbouncer
 chown postgres:postgres /var/log/pgbouncer /var/run/pgbouncer
 chmod 755 /var/log/pgbouncer /var/run/pgbouncer
+
+touch /var/log/pgbouncer/pgbouncer.log
+chown postgres:postgres /var/log/pgbouncer/pgbouncer.log
+chmod 640 /var/log/pgbouncer/pgbouncer.log
+
+# Enable and start pgbouncer service
+systemctl enable pgbouncer
+systemctl restart pgbouncer
+
 
 cat <<EOC > /etc/logrotate.d/pgbouncer
 /var/log/pgbouncer/pgbouncer.log {

--- a/cdk/scripts/pgbouncer-setup.sh
+++ b/cdk/scripts/pgbouncer-setup.sh
@@ -1,0 +1,252 @@
+#!/bin/bash
+set -euxo pipefail
+
+# These variables will be replaced by the TypeScript code
+SECRET_ARN=${SECRET_ARN}
+REGION=${REGION}
+POOL_MODE=${POOL_MODE}
+MAX_CLIENT_CONN=${MAX_CLIENT_CONN}
+DEFAULT_POOL_SIZE=${DEFAULT_POOL_SIZE}
+MIN_POOL_SIZE=${MIN_POOL_SIZE}
+RESERVE_POOL_SIZE=${RESERVE_POOL_SIZE}
+RESERVE_POOL_TIMEOUT=${RESERVE_POOL_TIMEOUT}
+MAX_DB_CONNECTIONS=${MAX_DB_CONNECTIONS}
+MAX_USER_CONNECTIONS=${MAX_USER_CONNECTIONS}
+
+# Add the postgres repository
+curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+
+# Install required packages
+apt-get update
+sleep 5
+DEBIAN_FRONTEND=noninteractive apt-get install -y pgbouncer jq awscli
+
+echo "Fetching secret from ARN: ${SECRET_ARN}"
+SECRET=$(aws secretsmanager get-secret-value --secret-id ${SECRET_ARN} --region ${REGION} --query SecretString --output text)
+
+# Before handling secrets, turn off command tracing
+set +x
+
+# Create a read-only file descriptor for sensitive operations
+exec 3<<< "$SECRET"
+
+# Parse database credentials without echoing
+DB_HOST=$(jq -r '.host' <&3)
+DB_PORT=$(jq -r '.port' <&3)
+DB_NAME=$(jq -r '.dbname' <&3)
+DB_USER=$(jq -r '.username' <&3)
+DB_PASSWORD=$(jq -r '.password' <&3)
+
+# Close the file descriptor
+exec 3<&-
+
+echo 'Creating PgBouncer configuration...'
+
+# Create pgbouncer.ini
+cat <<EOC > /etc/pgbouncer/pgbouncer.ini
+[databases]
+* = host=$DB_HOST port=$DB_PORT dbname=$DB_NAME
+
+[pgbouncer]
+listen_addr = 0.0.0.0
+listen_port = 5432
+auth_type = md5
+auth_file = /etc/pgbouncer/userlist.txt
+pool_mode = ${POOL_MODE}
+max_client_conn = ${MAX_CLIENT_CONN}
+default_pool_size = ${DEFAULT_POOL_SIZE}
+min_pool_size = ${MIN_POOL_SIZE}
+reserve_pool_size = ${RESERVE_POOL_SIZE}
+reserve_pool_timeout = ${RESERVE_POOL_TIMEOUT}
+max_db_connections = ${MAX_DB_CONNECTIONS}
+max_user_connections = ${MAX_USER_CONNECTIONS}
+ignore_startup_parameters = application_name,search_path
+logfile = /var/log/pgbouncer/pgbouncer.log
+pid_file = /var/run/pgbouncer/pgbouncer.pid
+admin_users = $DB_USER
+stats_users = $DB_USER
+log_connections = 1
+log_disconnections = 1
+log_pooler_errors = 1
+log_stats = 1
+stats_period = 60
+EOC
+
+# Create userlist.txt without echoing sensitive info
+{
+    echo "\"$DB_USER\" \"$DB_PASSWORD\""
+} > /etc/pgbouncer/userlist.txt
+
+# Turn command tracing back on
+set -x
+
+# Set correct permissions
+chown postgres:postgres /etc/pgbouncer/pgbouncer.ini /etc/pgbouncer/userlist.txt
+chmod 600 /etc/pgbouncer/pgbouncer.ini /etc/pgbouncer/userlist.txt
+
+# Enable and start pgbouncer service
+systemctl enable pgbouncer
+systemctl restart pgbouncer
+
+# Configure logging
+mkdir -p /var/log/pgbouncer /var/run/pgbouncer
+chown postgres:postgres /var/log/pgbouncer /var/run/pgbouncer
+chmod 755 /var/log/pgbouncer /var/run/pgbouncer
+
+cat <<EOC > /etc/logrotate.d/pgbouncer
+/var/log/pgbouncer/pgbouncer.log {
+    daily
+    rotate 7
+    compress
+    delaycompress
+    missingok
+    copytruncate
+    create 640 postgres postgres
+}
+EOC
+
+# Create monitoring scripts directory
+mkdir -p /opt/pgbouncer/scripts
+
+# Create the health check script
+cat <<'EOC' > /opt/pgbouncer/scripts/check-pgbouncer.sh
+#!/bin/bash
+if ! pgrep pgbouncer > /dev/null; then
+    systemctl start pgbouncer
+    echo 'PgBouncer was down, restarted' | logger -t pgbouncer-monitor
+fi
+EOC
+chmod +x /opt/pgbouncer/scripts/check-pgbouncer.sh
+
+# Create a single crontab file
+cat <<'EOC' > /opt/pgbouncer/scripts/crontab.txt
+# PgBouncer health check - run every minute
+* * * * * /opt/pgbouncer/scripts/check-pgbouncer.sh
+# PgBouncer metrics collection - run every minute
+* * * * * /opt/pgbouncer/scripts/pgbouncer-metrics.sh
+EOC
+
+# Install the crontab as the root user
+crontab /opt/pgbouncer/scripts/crontab.txt
+
+# Verify the crontab was installed
+if ! crontab -l; then
+    echo 'Failed to install crontab' | logger -t pgbouncer-setup
+    exit 1
+fi
+
+# Create per-boot script directory
+mkdir -p /var/lib/cloud/scripts/per-boot
+
+# Create per-boot script
+cat <<'EOF' > /var/lib/cloud/scripts/per-boot/00-run-config.sh
+#!/bin/bash
+# Stop existing services
+systemctl stop pgbouncer
+
+# Re-run configuration
+curl -o /tmp/user-data http://169.254.169.254/latest/user-data
+chmod +x /tmp/user-data
+/tmp/user-data
+EOF
+
+chmod +x /var/lib/cloud/scripts/per-boot/00-run-config.sh
+
+# Create CloudWatch configuration directory
+mkdir -p /opt/pgbouncer/cloudwatch
+
+# Install CloudWatch agent
+if ! wget https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb; then
+    echo 'Failed to download CloudWatch agent' | logger -t pgbouncer-setup
+    exit 1
+fi
+
+if ! dpkg -i amazon-cloudwatch-agent.deb; then
+    echo 'Failed to install CloudWatch agent' | logger -t pgbouncer-setup
+    exit 1
+fi
+
+# Create CloudWatch config
+cat <<EOC > /opt/aws/amazon-cloudwatch-agent/bin/config.json
+{
+  "agent": {
+    "metrics_collection_interval": 60,
+    "run_as_user": "root"
+  },
+  "logs": {
+    "logs_collected": {
+      "files": {
+        "collect_list": [
+          {
+            "file_path": "/var/log/pgbouncer/pgbouncer.log",
+            "log_group_name": "/pgbouncer/logs",
+            "log_stream_name": "{instance_id}",
+            "timestamp_format": "%Y-%m-%d %H:%M:%S",
+            "multi_line_start_pattern": "{timestamp_format}",
+            "retention_in_days": 14
+          },
+          {
+            "file_path": "/var/log/syslog",
+            "log_group_name": "/pgbouncer/system-logs",
+            "log_stream_name": "{instance_id}",
+            "timestamp_format": "%b %d %H:%M:%S",
+            "retention_in_days": 14
+          }
+        ]
+      }
+    }
+  },
+  "metrics": {
+    "metrics_collected": {
+      "procstat": [
+        {
+          "pattern": "pgbouncer",
+          "measurement": [
+            "cpu_usage",
+            "memory_rss",
+            "read_bytes",
+            "write_bytes",
+            "read_count",
+            "write_count",
+            "open_fd"
+          ]
+        }
+      ],
+      "mem": {
+        "measurement": [
+          "mem_used_percent"
+        ]
+      },
+      "disk": {
+        "measurement": [
+          "used_percent"
+        ]
+      }
+    },
+    "aggregation_dimensions": [["InstanceId"]]
+  }
+}
+EOC
+
+# Verify the config file exists
+if [ ! -f /opt/pgbouncer/cloudwatch/config.json ]; then
+    echo 'CloudWatch config file not created' | logger -t pgbouncer-setup
+    exit 1
+fi
+
+# Start CloudWatch agent
+if ! /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/opt/pgbouncer/cloudwatch/config.json; then
+    echo 'Failed to configure CloudWatch agent' | logger -t pgbouncer-setup
+    exit 1
+fi
+
+systemctl enable amazon-cloudwatch-agent
+systemctl start amazon-cloudwatch-agent
+
+# Verify CloudWatch agent is running
+if ! systemctl is-active amazon-cloudwatch-agent; then
+    echo 'CloudWatch agent failed to start' | logger -t pgbouncer-setup
+    exit 1
+fi
+

--- a/cdk/scripts/pgbouncer-setup.sh
+++ b/cdk/scripts/pgbouncer-setup.sh
@@ -91,6 +91,11 @@ chown postgres:postgres /etc/pgbouncer/pgbouncer.ini /etc/pgbouncer/userlist.txt
 chmod 600 /etc/pgbouncer/pgbouncer.ini /etc/pgbouncer/userlist.txt
 
 # Configure logging
+# ensure /var/run/pgbouncer gets created on boot
+cat <<EOC > /etc/tmpfiles.d/pgbouncer.conf
+d /var/run/pgbouncer 0755 postgres postgres -
+EOC
+
 mkdir -p /var/log/pgbouncer /var/run/pgbouncer
 chown postgres:postgres /var/log/pgbouncer /var/run/pgbouncer
 chmod 755 /var/log/pgbouncer /var/run/pgbouncer

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "aws-cdk-lib": "^2.130.0",
-    "eoapi-cdk": "7.2.1",
+    "eoapi-cdk": "7.3.0",
     "constructs": "^10.3.0",
     "source-map-support": "^0.5.16"
   }


### PR DESCRIPTION
## Overview
titiler-pgstac and any other serverless functions that can send many simultaneous requests to the pgstac database can quickly overwhelm the database resources. This PR adds an EC2 instance running `pgbouncer` to the MAAP eoAPI stack, providing connection pooling for titiler-pgstac requests.

## Features
- Connection pooling sets the maximum connections to the actual database instance to 25
- `pool_mode = transaction` provides high performance for many inbound requests
- CloudWatch logging is set up for the pgbouncer process
- With these changes, the `test` deployment which is running a `t3.micro` RDS instance is performing significantly better* than the `t3.small` instance on the `dev` deployment
  - based on subjective assessment of slippy map tile rendering.
  - Without these changes the `test` deployment is basically unusable for rendering large-scale mosaics.

## Questions
- Are there any other security measures we need to consider with this approach? @jjfrench
- Should the `pgbouncer` configuration settings be dynamic according to the pgstac database size? @bitner

This is one approach for solving https://github.com/NASA-IMPACT/active-maap-sprint/issues/1052