### PR TITLE
Fix broken links to collections/items in STAC Browser

### DIFF
--- a/cdk/PgStacInfra.ts
+++ b/cdk/PgStacInfra.ts
@@ -253,6 +253,8 @@ export class PgStacInfra extends Stack {
     });
 
     // STAC Browser Infrastructure
+    const rootPath = "index.html";
+
     const stacBrowserBucket = new s3.Bucket(this, "stacBrowserBucket", {
       accessControl: s3.BucketAccessControl.PRIVATE,
       removalPolicy: RemovalPolicy.DESTROY,
@@ -266,7 +268,7 @@ export class PgStacInfra extends Stack {
       "stacBrowserDistro",
       {
         defaultBehavior: { origin: new origins.S3Origin(stacBrowserBucket) },
-        defaultRootObject: "index.html",
+        defaultRootObject: rootPath,
         domainNames: [props.stacBrowserCustomDomainName],
         certificate: acm.Certificate.fromCertificateArn(
           this,
@@ -280,13 +282,13 @@ export class PgStacInfra extends Stack {
           {
             httpStatus: 403,
             responseHttpStatus: 200,
-            responsePagePath: "/index.html",
+            responsePagePath: rootPath,
             ttl: Duration.seconds(0),
           },
           {
             httpStatus: 404,
             responseHttpStatus: 200,
-            responsePagePath: "/index.html",
+            responsePagePath: rootPath,
             ttl: Duration.seconds(0),
           },
         ],
@@ -299,7 +301,7 @@ export class PgStacInfra extends Stack {
         ? props.stacApiCustomDomainName
         : `https://${props.stacApiCustomDomainName}/`,
       githubRepoTag: props.stacBrowserRepoTag,
-      websiteIndexDocument: "index.html",
+      websiteIndexDocument: rootPath,
     });
 
     const accountId = Aws.ACCOUNT_ID;

--- a/cdk/PgStacInfra.ts
+++ b/cdk/PgStacInfra.ts
@@ -276,6 +276,20 @@ export class PgStacInfra extends Stack {
         enableLogging: true,
         logBucket: maapLoggingBucket,
         logFilePrefix: "stac-browser",
+        errorResponses: [
+          {
+            httpStatus: 403,
+            responseHttpStatus: 200,
+            responsePagePath: "/index.html",
+            ttl: Duration.seconds(0),
+          },
+          {
+            httpStatus: 404,
+            responseHttpStatus: 200,
+            responsePagePath: "/index.html",
+            ttl: Duration.seconds(0),
+          },
+        ],
       },
     );
 


### PR DESCRIPTION
There's an easy fix that lets Vue.js do the right thing and bring users to their intended destination.

I deployed this change to the `test` deployment and now direct links work:
https://stac-browser.dit.maap-project.org/collections/glad-glclu2020-v2

Resolves #42 