### PR TITLE
update to eoapi-cdk 7.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "aws-cdk-lib": "^2.130.0",
     "constructs": "^10.3.0",
-    "eoapi-cdk": "^7.6.1",
+    "eoapi-cdk": "^7.6.2",
     "source-map-support": "^0.5.16"
   }
 }


### PR DESCRIPTION
fixes collection ingestion - I tested it out with `glad-global-forest-change-1.11` and it worked fine.