### PR TITLE
upgrade to eoapi v8.0.1, update MosaicTilerFactory for titiler>=21

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,6 +56,7 @@ jobs:
         INGESTOR_DOMAIN_NAME: ${{ vars.INGESTOR_DOMAIN_NAME }}
         JWKS_URL: ${{ steps.import-stacks-vars-to-output.outputs.JWKS_URL }}
         MOSAIC_HOST: ${{ vars.MOSAIC_HOST }}
+        PGSTAC_VERSION: ${{ vars.PGSTAC_VERSION }}
         STAC_API_CUSTOM_DOMAIN_NAME: ${{ vars.STAC_API_CUSTOM_DOMAIN_NAME}}
         STAC_API_INTEGRATION_API_ARN: ${{ vars.STAC_API_INTEGRATION_API_ARN }}
         STAC_BROWSER_CERTIFICATE_ARN: ${{ vars.STAC_BROWSER_CERTIFICATE_ARN }}

--- a/cdk/PgStacInfra.ts
+++ b/cdk/PgStacInfra.ts
@@ -40,6 +40,7 @@ export class PgStacInfra extends Stack {
       allocatedStorage,
       mosaicHost,
       titilerBucketsPath,
+      pgstacVersion,
     } = props;
 
     const maapLoggingBucket = new s3.Bucket(this, "maapLoggingBucket", {
@@ -71,6 +72,7 @@ export class PgStacInfra extends Stack {
       allocatedStorage: allocatedStorage,
       instanceType: dbInstanceType,
       addPgbouncer: true,
+      pgstacVersion: pgstacVersion,
     });
 
     const apiSubnetSelection: ec2.SubnetSelection = {
@@ -446,4 +448,9 @@ export interface Props extends StackProps {
    * Example: "arn:aws:acm:us-west-2:123456789012:certificate/12345678-1234-1234-1234-123456789012"
    */
   stacBrowserCertificateArn: string;
+
+  /**
+   * version of pgstac to install on the database
+   */
+  pgstacVersion: string;
 }

--- a/cdk/PgStacInfra.ts
+++ b/cdk/PgStacInfra.ts
@@ -231,6 +231,7 @@ export class PgStacInfra extends Stack {
         JWKS_URL: jwksUrl,
         REQUESTER_PAYS: "true",
       },
+      pgstacVersion,
       ingestorDomainNameOptions:
         props.IngestorDomainName && props.certificateArn
           ? {

--- a/cdk/app.ts
+++ b/cdk/app.ts
@@ -24,6 +24,7 @@ const {
   stacBrowserRepoTag,
   stacBrowserCustomDomainName,
   stacBrowserCertificateArn,
+  pgstacVersion,
 } = new Config();
 
 export const app = new cdk.App({});
@@ -63,4 +64,5 @@ new PgStacInfra(app, buildStackName("pgSTAC"), {
   stacBrowserRepoTag: stacBrowserRepoTag,
   stacBrowserCustomDomainName: stacBrowserCustomDomainName,
   stacBrowserCertificateArn: stacBrowserCertificateArn,
+  pgstacVersion: pgstacVersion,
 });

--- a/cdk/config.ts
+++ b/cdk/config.ts
@@ -18,6 +18,7 @@ export class Config {
   readonly stacBrowserRepoTag: string;
   readonly stacBrowserCustomDomainName: string;
   readonly stacBrowserCertificateArn: string;
+  readonly pgstacVersion: string;
 
   constructor() {
     // These are required environment variables and cannot be undefined
@@ -54,6 +55,10 @@ export class Config {
       {
         name: "STAC_API_CUSTOM_DOMAIN_NAME",
         value: process.env.STAC_API_CUSTOM_DOMAIN_NAME,
+      },
+      {
+        name: "PGSTAC_VERSION",
+        value: process.env.PGSTAC_VERSION,
       },
     ];
 
@@ -102,6 +107,7 @@ export class Config {
     this.ingestorDomainName = process.env.INGESTOR_DOMAIN_NAME;
     this.titilerPgStacApiCustomDomainName =
       process.env.TITILER_PGSTAC_API_CUSTOM_DOMAIN_NAME;
+    this.pgstacVersion = process.env.PGSTAC_VERSION!;
   }
 
   /**

--- a/cdk/runtimes/eoapi/raster/eoapi/raster/factory.py
+++ b/cdk/runtimes/eoapi/raster/eoapi/raster/factory.py
@@ -5,13 +5,13 @@ import logging
 import os
 import uuid
 from asyncio import wait_for
-from dataclasses import dataclass
 from functools import partial
 from typing import Annotated, Dict, List, Optional
 from urllib.parse import urlencode
 
 import morecantile
 import rasterio
+from attrs import define
 from cogeo_mosaic.backends import DynamoDBBackend
 from cogeo_mosaic.errors import MosaicError
 from cogeo_mosaic.mosaic import MosaicJSON
@@ -44,12 +44,11 @@ from eoapi.raster.settings import MosaicSettings
 mosaic_config = MosaicSettings()
 
 
-@dataclass
+@define(kw_only=True)
 class MosaicTilerFactory(factory.MosaicTilerFactory):
     """Custom MosaicTiler Factory."""
 
     logger = logging.getLogger(__name__)
-    tms = morecantile.tms.get("WebMercatorQuad")
 
     def register_routes(self):  # noqa
         """This Method register routes to the router."""

--- a/cdk/runtimes/eoapi/raster/pyproject.toml
+++ b/cdk/runtimes/eoapi/raster/pyproject.toml
@@ -19,10 +19,8 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "titiler.pgstac==1.3.1",
-    "titiler.extensions[cogeo]==0.18.10",
-    "titiler.mosaic==0.18.10",
-    "titiler.pgstac==1.3.1",
+    "titiler.pgstac==1.7.1",
+    "titiler.extensions[cogeo]>=0.21,<0.22",
     "pystac-client==0.8.4",
     "stac-pydantic==3.1.3",
     "importlib_resources>=1.1.0;python_version<'3.9'",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "aws-cdk-lib": "^2.130.0",
         "constructs": "^10.3.0",
-        "eoapi-cdk": "^7.6.1",
+        "eoapi-cdk": "^8.0.2",
         "source-map-support": "^0.5.16"
       },
       "bin": {
@@ -2415,9 +2415,9 @@
       }
     },
     "node_modules/eoapi-cdk": {
-      "version": "7.6.1",
-      "resolved": "https://registry.npmjs.org/eoapi-cdk/-/eoapi-cdk-7.6.1.tgz",
-      "integrity": "sha512-ptnGK+ROmhXKvfRMKPuRXkUyuUSdFHstBDLuKkddV9qWLWBqohQoBny5EcEx3PUGEmLLc3K9C+FXaitNngsNyw==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/eoapi-cdk/-/eoapi-cdk-8.0.2.tgz",
+      "integrity": "sha512-vLSzv74aAX4MVBjk0BL/yQIfE/Dy/iXugMqAwVgMlqIg3x+wCmm/CB41NulAB0q///qBE+ue66QcK6qYwrB9Nw==",
       "license": "ISC",
       "dependencies": {
         "@aws-cdk/aws-apigatewayv2-alpha": "2.114.1-alpha.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "aws-cdk-lib": "^2.130.0",
     "constructs": "^10.3.0",
-    "eoapi-cdk": "^8.0.1",
+    "eoapi-cdk": "^8.0.2",
     "source-map-support": "^0.5.16"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "aws-cdk-lib": "^2.130.0",
     "constructs": "^10.3.0",
-    "eoapi-cdk": "^7.6.2",
+    "eoapi-cdk": "^8.0.0",
     "source-map-support": "^0.5.16"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "aws-cdk-lib": "^2.130.0",
     "constructs": "^10.3.0",
-    "eoapi-cdk": "^8.0.0",
+    "eoapi-cdk": "^8.0.1",
     "source-map-support": "^0.5.16"
   }
 }


### PR DESCRIPTION
eoapi-cdk==8.0.1 brings our stack up to date with the latest of `titiler`, `titiler-pgstac`, and `stac-fastapi-pgstac`.

The list of improvements includes:
- `datetime`, `bbox`, and `ids` query parameters for the `/collections` endpoints in titiler-pgstac for quick filtering on tile endpoints
  - for example, adding the `datetime=2020-01-01T00:00:00Z/2020-12-31T23:59:59Z` to a [`/map` endpoint request](https://titiler-pgstac.dit.maap-project.org/collections/global-mangrove-watch-3.0/WebMercatorQuad/map?colormap=%7B%221%22%3A+%5B0%2C+150%2C+0%5D%7D&assets=cog&datetime=2020-01-01T00:00:00Z/2020-12-31T23:59:59Z&bbox=-82,24.4,-80,25.8) gives you tiles from items in 2020 while [`datetime=2007-01-01T00:00:00Z/2007-12-31T23:59:59Z`](https://titiler-pgstac.dit.maap-project.org/collections/global-mangrove-watch-3.0/WebMercatorQuad/map?colormap=%7B%221%22%3A+%5B0%2C+150%2C+0%5D%7D&assets=cog&datetime=2007-01-01T00:00:00Z/2007-12-31T23:59:59Z&bbox=-82,24.4,-80,25.8) will give you tiles from items in 2005
  - also note the `bbox=-82,24.4,-80,25.8` which will limit the items (and the map view in this case) to a specific bounding box
- better `/map` endpoint (layer control, imagery tiles)
- collection search with free-text capability in pgstac + stac-fastapi-pgstac

I am also adding `PGSTAC_VERSION` as a configuration parameter to the deployment and setting it to the latest version (0.9.5).