### PR TITLE
add request logging middleware to titiler app

### DIFF
--- a/cdk/PgStacInfra.ts
+++ b/cdk/PgStacInfra.ts
@@ -219,8 +219,8 @@ export class PgStacInfra extends Stack {
       queryLines: [
         "fields @timestamp, @message",
         'filter @message like "Request:"',
-        'parse @message \'"path_template": "*",\' as path_template',
-        "stats count(*) as count by path_template",
+        'parse @message \'"route": "*",\' as route',
+        "stats count(*) as count by route",
         "sort count desc",
         "limit 20",
       ],

--- a/cdk/handlers/raster_handler.py
+++ b/cdk/handlers/raster_handler.py
@@ -3,36 +3,77 @@
 import asyncio
 import logging
 import os
-
-from eoapi.raster.utils import get_secret_dict
-
-# Update postgres env variables before importing titiler.pgstac.main
-pgstac_secret_arn = os.environ["PGSTAC_SECRET_ARN"]
-pgbouncer_host = os.getenv("PGBOUNCER_HOST")
-
-secret = get_secret_dict(pgstac_secret_arn)
-os.environ.update(
-    {
-        "postgres_host": pgbouncer_host or secret["host"],
-        "postgres_dbname": secret["dbname"],
-        "postgres_user": secret["username"],
-        "postgres_pass": secret["password"],
-        "postgres_port": str(secret["port"]),
-    }
-)
+import re
 
 from eoapi.raster.main import app
+from eoapi.raster.utils import get_secret_dict
+from fastapi import Request
+from fastapi.routing import APIRoute
 from mangum import Mangum
 from titiler.pgstac.db import connect_to_db
+from titiler.pgstac.settings import PostgresSettings
 
 logging.getLogger("mangum.lifespan").setLevel(logging.ERROR)
 logging.getLogger("mangum.http").setLevel(logging.ERROR)
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+pgstac_secret_arn = os.environ["PGSTAC_SECRET_ARN"]
+pgbouncer_host = os.getenv("PGBOUNCER_HOST")
+secret = get_secret_dict(pgstac_secret_arn)
+
+pg_settings = PostgresSettings(
+    postgres_host=pgbouncer_host or secret["host"],
+    postgres_dbname=secret["dbname"],
+    postgres_user=secret["username"],
+    postgres_pass=secret["password"],
+    postgres_port=secret["port"],
+)
 
 
 @app.on_event("startup")
 async def startup_event() -> None:
     """Connect to database on startup."""
-    await connect_to_db(app)
+    await connect_to_db(app, settings=pg_settings)
+
+    app.state.path_templates = {}
+    for route in app.routes:
+        if isinstance(route, APIRoute):
+            # Convert FastAPI path pattern to regex pattern
+            pattern = re.sub(r"{([^}]+)}", r"(?P<\1>[^/]+)", route.path)
+            app.state.path_templates[re.compile(f"^{pattern}$")] = route.path
+
+
+@app.middleware("http")
+async def log_request_data(request: Request, call_next):
+    path = request.url.path
+    method = request.method
+    query_params = dict(request.query_params)
+
+    # Extract path parameters
+    path_template = path
+    path_params = {}
+
+    for pattern, template in app.state.path_templates.items():
+        match = pattern.match(path)
+        if match:
+            path_template = template
+            path_params = match.groupdict()
+            break
+
+    log_data = {
+        "method": method,
+        "path_template": path_template,
+        "path": path,
+        "path_params": path_params,
+        "query_params": query_params,
+    }
+
+    logger.info(f"Request: {log_data}")
+
+    response = await call_next(request)
+    return response
 
 
 handler = Mangum(app, lifespan="off")

--- a/cdk/handlers/raster_handler.py
+++ b/cdk/handlers/raster_handler.py
@@ -55,19 +55,19 @@ async def log_request_data(request: Request, call_next):
     query_params = dict(request.query_params)
 
     # Extract path parameters
-    path_template = path
+    route = path
     path_params = {}
 
-    for pattern, template in app.state.path_templates.items():
+    for pattern, _route in app.state.path_templates.items():
         match = pattern.match(path)
         if match:
-            path_template = template
+            route = _route
             path_params = match.groupdict()
             break
 
     log_data = {
         "method": method,
-        "path_template": path_template,
+        "route": route,
         "path": path,
         "path_params": path_params,
         "query_params": query_params,

--- a/cdk/handlers/raster_handler.py
+++ b/cdk/handlers/raster_handler.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import re
+from urllib.parse import urlparse
 
 from eoapi.raster.main import app
 from eoapi.raster.utils import get_secret_dict
@@ -64,14 +65,20 @@ async def log_request_data(request: Request, call_next):
             path_params = match.groupdict()
             break
 
-    # Build log data
     log_data = {
         "method": method,
         "path_template": path_template,
         "path": path,
         "path_params": path_params,
         "query_params": query_params,
+        "url_scheme": None,
+        "url_netloc": None,
     }
+
+    if url := query_params.get("url"):
+        url_parsed = urlparse(url)
+        log_data["url_scheme"] = url_parsed.scheme
+        log_data["url_netloc"] = url_parsed.netloc
 
     logger.info(f"Request: {json.dumps(log_data)}")
 

--- a/cdk/handlers/raster_handler.py
+++ b/cdk/handlers/raster_handler.py
@@ -41,24 +41,10 @@ async def startup_event() -> None:
     app.state.path_templates = {}
     for route in app.routes:
         if isinstance(route, APIRoute):
-            # Extract original parameter names
-            original_params = re.findall(r"{([^}]+)}", route.path)
-
-            # Create pattern with sanitized parameter names
-            pattern = route.path
-            for param in original_params:
-                # Replace special chars with underscore for the regex group name
-                safe_name = re.sub(r"[^0-9a-zA-Z_]", "_", param)
-                # Replace the param in the pattern
-                pattern = pattern.replace(f"{{{param}}}", f"(?P<{safe_name}>[^/]+)")
-
-            # Store the mapping of regex pattern to original route path
-            app.state.path_templates[re.compile(f"^{pattern}$")] = {
-                "template": route.path,
-                "param_mapping": {
-                    re.sub(r"[^0-9a-zA-Z_]", "_", p): p for p in original_params
-                },
-            }
+            # replace : with _ to make it regexable
+            route_path = route.path.replace(":", "__")
+            pattern = re.sub(r"{([^}]+)}", r"(?P<\1>[^/]+)", route_path)
+            app.state.path_templates[re.compile(f"^{pattern}$")] = route_path
 
 
 @app.middleware("http")
@@ -71,18 +57,14 @@ async def log_request_data(request: Request, call_next):
     path_template = path
     path_params = {}
 
-    for pattern, route_info in app.state.path_templates.items():
+    for pattern, template in app.state.path_templates.items():
         match = pattern.match(path)
         if match:
-            path_template = route_info["template"]
-            # Get regex-captured params
-            captured_params = match.groupdict()
-            # Map back to original parameter names
-            for safe_name, value in captured_params.items():
-                original_name = route_info["param_mapping"].get(safe_name, safe_name)
-                path_params[original_name] = value
+            path_template = template
+            path_params = match.groupdict()
             break
 
+    # Build log data
     log_data = {
         "method": method,
         "path_template": path_template,

--- a/cdk/runtimes/eoapi/raster/eoapi/raster/main.py
+++ b/cdk/runtimes/eoapi/raster/eoapi/raster/main.py
@@ -2,6 +2,8 @@
 Handler for AWS Lambda.
 """
 
+import logging
+
 from fastapi import APIRouter, Request
 from fastapi.responses import RedirectResponse
 from rio_tiler.io import STACReader
@@ -14,6 +16,22 @@ from titiler.extensions import (
 from titiler.pgstac.main import app  # noqa: E402
 
 from eoapi.raster.factory import MosaicTilerFactory
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+@app.middleware("http")
+async def log_request_params(request: Request, call_next):
+    """Log request details"""
+    query_params = dict(request.query_params)
+    path = request.url.path
+    method = request.method
+
+    logger.info(f"Request: {method} {path} - Query parameters: {query_params}")
+
+    response = await call_next(request)
+    return response
 
 
 ########################################

--- a/cdk/runtimes/eoapi/raster/eoapi/raster/main.py
+++ b/cdk/runtimes/eoapi/raster/eoapi/raster/main.py
@@ -2,8 +2,6 @@
 Handler for AWS Lambda.
 """
 
-import logging
-
 from fastapi import APIRouter, Request
 from fastapi.responses import RedirectResponse
 from rio_tiler.io import STACReader
@@ -16,23 +14,6 @@ from titiler.extensions import (
 from titiler.pgstac.main import app  # noqa: E402
 
 from eoapi.raster.factory import MosaicTilerFactory
-
-logger = logging.getLogger()
-logger.setLevel(logging.INFO)
-
-
-@app.middleware("http")
-async def log_request_params(request: Request, call_next):
-    """Log request details"""
-    query_params = dict(request.query_params)
-    path = request.url.path
-    method = request.method
-
-    logger.info(f"Request: {method} {path} - Query parameters: {query_params}")
-
-    response = await call_next(request)
-    return response
-
 
 ########################################
 # Include the /cog router


### PR DESCRIPTION
We want to get some insights into how the `titiler` app is getting used to help us decide what to do with with respect to access to files over s3, https, etc.

This middleware will dump logs like this into CloudWatch:
```
[INFO]	2025-03-21T02:16:30.295Z	b0924a91-1064-4e23-9733-977948d304d2	Request: 
{
    "method": "GET",
    "path_template": "/cog/tiles/{tileMatrixSetId}/{z}/{x}/{y}@{scale}x",
    "path": "/cog/tiles/WebMercatorQuad/10/355/506@1x",
    "path_params": {
        "tileMatrixSetId": "WebMercatorQuad",
        "z": "10",
        "x": "355",
        "y": "506",
        "scale": "1"
    },
    "query_params": {
        "url": "https://e84-earth-search-sentinel-data.s3.us-west-2.amazonaws.com/sentinel-2-pre-c1-l2a/21/N/YC/2022/12/S2B_T21NYC_20221205T140704_L2A/B04.tif",
        "colormap_name": "greens",
        "rescale": "0,4000"
    }
}
```

~We should be able to parse that JSON in the CloudWatch console or maybe make a dashboard or something like that.~
We can add a dashboard with some widgets that parse the logs and deploy it via CDK!

![image](https://github.com/user-attachments/assets/9c2a888f-ddad-47e6-827b-4bb6567bf968)

resolves https://github.com/NASA-IMPACT/active-maap-sprint/issues/1134
