### PR TITLE
a few small titiler dashboard tweaks

### DIFF
--- a/cdk/PgStacInfra.ts
+++ b/cdk/PgStacInfra.ts
@@ -226,6 +226,25 @@ export class PgStacInfra extends Stack {
       ],
     });
 
+    // widget showing count by referer
+    const titilerRefererAnalysisWidget = new cloudwatch.LogQueryWidget({
+      logGroupNames: [
+        titilerPgstacApi.titilerPgstacLambdaFunction.logGroup.logGroupName,
+      ],
+      title: "titiler /cog requests by url scheme and netloc",
+      width: 6,
+      height: 8,
+      view: cloudwatch.LogQueryVisualizationType.TABLE,
+      queryLines: [
+        "fields @timestamp, @message",
+        'filter @message like "Request:"',
+        'parse @message \'"referer": "*"\' as referer',
+        "stats count(*) as count by referer",
+        "sort count desc",
+        "limit 20",
+      ],
+    });
+
     // widget showing count by scheme/netloc for routes with url parameter
     const titilerUrlAnalysisWidget = new cloudwatch.LogQueryWidget({
       logGroupNames: [
@@ -293,6 +312,7 @@ export class PgStacInfra extends Stack {
       titilerCollectionAnalysisWidget,
       titilerSearchesAnalysisWidget,
       titilerUrlAnalysisWidget,
+      titilerRefererAnalysisWidget,
     );
 
     // STAC Ingestor

--- a/cdk/PgStacInfra.ts
+++ b/cdk/PgStacInfra.ts
@@ -208,13 +208,13 @@ export class PgStacInfra extends Stack {
     });
 
     // widget showing count by application route
-    const titilerLogWidget = new cloudwatch.LogQueryWidget({
+    const titilerRouteLogWidget = new cloudwatch.LogQueryWidget({
       logGroupNames: [
         titilerPgstacApi.titilerPgstacLambdaFunction.logGroup.logGroupName,
       ],
       title: "titiler requests by route",
-      width: 24,
-      height: 6,
+      width: 12,
+      height: 8,
       view: cloudwatch.LogQueryVisualizationType.TABLE,
       queryLines: [
         "fields @timestamp, @message",
@@ -232,7 +232,7 @@ export class PgStacInfra extends Stack {
         titilerPgstacApi.titilerPgstacLambdaFunction.logGroup.logGroupName,
       ],
       title: "titiler /cog requests by url scheme and netloc",
-      width: 24,
+      width: 6,
       height: 8,
       view: cloudwatch.LogQueryVisualizationType.TABLE,
       queryLines: [
@@ -246,7 +246,54 @@ export class PgStacInfra extends Stack {
         "limit 20",
       ],
     });
-    eoapiDashboard.addWidgets(titilerLogWidget, titilerUrlAnalysisWidget);
+
+    // widget showing count by collection_id for /collections requests
+    const titilerCollectionAnalysisWidget = new cloudwatch.LogQueryWidget({
+      logGroupNames: [
+        titilerPgstacApi.titilerPgstacLambdaFunction.logGroup.logGroupName,
+      ],
+      title: "titiler /collections requests by collection id",
+      width: 6,
+      height: 8,
+      view: cloudwatch.LogQueryVisualizationType.TABLE,
+      queryLines: [
+        "fields @timestamp, @message",
+        'filter @message like "Request:"',
+        'parse @message \'"route": "*"\' as route',
+        'filter route like "/collections/"',
+        "parse @message '\"path_params\": {*}' as path_params",
+        "stats count(*) as count by path_params.collection_id as collection_id",
+        "sort count desc",
+        "limit 20",
+      ],
+    });
+
+    // widget showing count by collection_id for /collections requests
+    const titilerSearchesAnalysisWidget = new cloudwatch.LogQueryWidget({
+      logGroupNames: [
+        titilerPgstacApi.titilerPgstacLambdaFunction.logGroup.logGroupName,
+      ],
+      title: "titiler /searches requests by search id",
+      width: 6,
+      height: 8,
+      view: cloudwatch.LogQueryVisualizationType.TABLE,
+      queryLines: [
+        "fields @timestamp, @message",
+        'filter @message like "Request:"',
+        'parse @message \'"route": "*"\' as route',
+        'filter route like "/searches/"',
+        "parse @message '\"path_params\": {*}' as path_params",
+        "stats count(*) as count by path_params.search_id as search_id",
+        "sort count desc",
+        "limit 20",
+      ],
+    });
+    eoapiDashboard.addWidgets(
+      titilerRouteLogWidget,
+      titilerCollectionAnalysisWidget,
+      titilerSearchesAnalysisWidget,
+      titilerUrlAnalysisWidget,
+    );
 
     // STAC Ingestor
     const ingestorDataAccessRole = iam.Role.fromRoleArn(

--- a/cdk/PgStacInfra.ts
+++ b/cdk/PgStacInfra.ts
@@ -231,7 +231,7 @@ export class PgStacInfra extends Stack {
       logGroupNames: [
         titilerPgstacApi.titilerPgstacLambdaFunction.logGroup.logGroupName,
       ],
-      title: "titiler /cog requests by url scheme and netloc",
+      title: "titiler requests by request referer",
       width: 6,
       height: 8,
       view: cloudwatch.LogQueryVisualizationType.TABLE,

--- a/cdk/handlers/raster_handler.py
+++ b/cdk/handlers/raster_handler.py
@@ -54,8 +54,15 @@ async def log_request_data(request: Request, call_next):
     method = request.method
     query_params = dict(request.query_params)
 
-    # Extract path parameters
+    referer = request.headers.get("referer") or request.headers.get("referrer")
+    origin = request.headers.get("origin")
+
+    # find generic route path, fall back to actual route path if no match found
     route = path
+
+    # re-map /mosaic requests to new /searches/
+    route = route.replace("/mosaic/", "/searches/")
+
     path_params = {}
 
     for pattern, _route in app.state.path_templates.items():
@@ -67,6 +74,8 @@ async def log_request_data(request: Request, call_next):
 
     log_data = {
         "method": method,
+        "referer": referer,
+        "origin": origin,
         "route": route,
         "path": path,
         "path_params": path_params,


### PR DESCRIPTION
I added the `referer` and `origin` attributes to the request logs so we could see which websites requests are coming from (e.g. `https://ade.maap-project.org`), then added some more widgets to track usage of the `/collections` and `/searches` endpoints.

![image](https://github.com/user-attachments/assets/8cec1b95-96cb-4305-bbd4-d2467b9d8d96)
