### PR TITLE
patch: update eoapi-cdk to 8.1.1, undo loggingBucket change

### DIFF
--- a/cdk/app.ts
+++ b/cdk/app.ts
@@ -36,30 +36,11 @@ const { vpc } = new Vpc(app, buildStackName("vpc"), {
   natGatewayCount: stage === "prod" ? undefined : 1,
 });
 
-const loggingBucket = new cdk.aws_s3.Bucket(
-  app,
-  buildStackName("maapLoggingBucket"),
-  {
-    accessControl: cdk.aws_s3.BucketAccessControl.LOG_DELIVERY_WRITE,
-    removalPolicy: RemovalPolicy.DESTROY,
-    blockPublicAccess: cdk.aws_s3.BlockPublicAccess.BLOCK_ALL,
-    bucketName: `maap-logging-${stage}`,
-    enforceSSL: true,
-    lifecycleRules: [
-      {
-        enabled: true,
-        expiration: Duration.days(90),
-      },
-    ],
-  },
-);
-
 new PgStacInfra(app, buildStackName("pgSTAC"), {
   vpc,
   tags,
   stage,
   version,
-  loggingBucket,
   certificateArn,
   pgstacDbConfig: {
     instanceType: dbInstanceType,

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "aws-cdk-lib": "^2.190.0",
     "constructs": "^10.3.0",
-    "eoapi-cdk": "^8.1.0",
+    "eoapi-cdk": "^8.1.1",
     "source-map-support": "^0.5.16"
   }
 }


### PR DESCRIPTION
I had to move the loggingBucket back into PgStacInfra because buckets need to be in a `stack`. I guess I should have tested that out before merging #53.