### PR TITLE
feat: bump pgstac database up to postgresql 15

### DIFF
--- a/cdk/PgStacInfra.ts
+++ b/cdk/PgStacInfra.ts
@@ -55,7 +55,7 @@ export class PgStacInfra extends Stack {
       vpc,
       allowMajorVersionUpgrade: true,
       engine: rds.DatabaseInstanceEngine.postgres({
-        version: rds.PostgresEngineVersion.VER_14,
+        version: rds.PostgresEngineVersion.VER_15,
       }),
       vpcSubnets: {
         subnetType: pgstacDbConfig.subnetPublic


### PR DESCRIPTION
This is the first of three sequential upgrades we need to perform on the pgstac RDS database instances.

### Prerequisite manual database update
For each RDS database instance, do the following before attempting to upgrade the PostgreSQL version:

1. Go to secrets manager and find the secret with the root user credentials

2. Connect to the pgbouncer EC2 instance corresponding to the database

3. Install `postgresql-client-14`

```bash
sudo apt update && sudo apt install postgresql-client-14
```

4. Set environment variables to connect to the PostgreSQL database as the root user (`postgres`)
```bash
# these are constants
export PGPORT=5432
export PGDATABASE=pgstac
export PGUSER=postgres

# these are variable
export PGPASSWORD=
export PGHOST=
```

5. Connect to the database and update the function signature for the `pgstac` functions so that the `search_path` includes the `public` schema
```bash
psql  -c "

DO $$
DECLARE
    -- Variable to hold the full, unambiguous signature of each function
    func_signature text;
BEGIN
    -- Loop through all functions in the 'pgstac' schema
    FOR func_signature IN
        SELECT
            -- This casts the function's OID to its formal signature,
            -- e.g., 'pgstac.collection_geom(jsonb)'
            p.oid::regprocedure::text
        FROM
            pg_proc p
        JOIN
            pg_namespace n ON p.pronamespace = n.oid
        WHERE
            n.nspname = 'pgstac' AND p.prokind = 'f' -- Ensures we only alter actual functions
    LOOP
        -- Build and execute the ALTER FUNCTION command using the full signature
        RAISE NOTICE 'Hardening function: %', func_signature;
        EXECUTE format(
            'ALTER FUNCTION %s SET search_path = pgstac, public, pg_catalog;',
            func_signature
        );
    END LOOP;
    RAISE NOTICE 'All functions in pgstac schema have been updated.';
END;
$$;
"
```
