### PR TITLE
feat: enable context extension in pgstac database

### DIFF
--- a/cdk/PgStacInfra.ts
+++ b/cdk/PgStacInfra.ts
@@ -65,6 +65,7 @@ export class PgStacInfra extends Stack {
       instanceType: pgstacDbConfig.instanceType,
       addPgbouncer: true,
       pgstacVersion: pgstacDbConfig.pgstacVersion,
+      customResourceProperties: { context: true },
     });
 
     const apiSubnetSelection: ec2.SubnetSelection = {


### PR DESCRIPTION
This will enable STAC searches to have the `numberMatched` field which tells you how many items there are that match your search so you don't have to page through all of the results.

I deployed this to the test deployment and it works as intended:

https://bc7g3hu415.execute-api.us-west-2.amazonaws.com/search?limit=1

```
{
  ...,
  "numberMatched": 399407,
  "numberReturned": 1
}
```