### PR TITLE
fix: increase pgstac db bootstrap lambda timeout to 15 minutes

### DIFF
--- a/cdk/PgStacInfra.ts
+++ b/cdk/PgStacInfra.ts
@@ -66,6 +66,7 @@ export class PgStacInfra extends Stack {
       addPgbouncer: true,
       pgstacVersion: pgstacDbConfig.pgstacVersion,
       customResourceProperties: { context: true },
+      bootstrapperLambdaFunctionOptions: { timeout: Duration.minutes(15) },
     });
 
     const apiSubnetSelection: ec2.SubnetSelection = {


### PR DESCRIPTION
This PR increases the timeout to 15 minutes (the logs indicate that whatever operation we need to do takes ~5 minutes).

For some reason the userSTAC pgstac database on the `dev` deployment is hitting the 2 minute Lambda timeout on the pgstac bootstrap process when upgrading from pgstac 0.9.7 to 0.9.9. All of the other database instances had no trouble with this operation :thinking:.

I worry that there is something special about the user STAC database structure that is going to make this problem get worse over time. My hunch is that it is related to the number of collections. As of 1/26/2026 there are 852 collections in there, I expect that number to keep growing rapidly.

Here is the full error log that I found in the RDS logs:
```
2026-01-26 19:02:05 UTC::@:[1337]:LOG:  checkpoint starting: time
2026-01-26 19:02:06 UTC::@:[1337]:LOG:  checkpoint complete: wrote 10 buffers (0.0%); 0 WAL file(s) added, 2 removed, 0 recycled; write=1.028 s, sync=0.005 s, total=1.047 s; sync files=10, longest=0.005 s, average=0.001 s; distance=65542 kB, estimate=65542 kB; lsn=44B/B4000060, redo lsn=44B/B0001FA0
2026-01-26 19:07:05 UTC::@:[1337]:LOG:  checkpoint starting: time
2026-01-26 19:07:06 UTC::@:[1337]:LOG:  checkpoint complete: wrote 3 buffers (0.0%); 0 WAL file(s) added, 1 removed, 0 recycled; write=0.327 s, sync=0.001 s, total=0.338 s; sync files=3, longest=0.001 s, average=0.001 s; distance=65529 kB, estimate=65541 kB; lsn=44B/B8000060, redo lsn=44B/B4000638
2026-01-26 19:12:05 UTC::@:[1337]:LOG:  checkpoint starting: time
2026-01-26 19:13:41 UTC:10.0.3.250(63498):postgres@pgstac:[2568]:LOG:  could not send data to client: Broken pipe
2026-01-26 19:13:41 UTC:10.0.3.250(63498):postgres@pgstac:[2568]:FATAL:  connection to client lost
2026-01-26 19:16:35 UTC::@:[1337]:LOG:  checkpoint complete: wrote 9455 buffers (14.4%); 0 WAL file(s) added, 8 removed, 3 recycled; write=269.665 s, sync=0.180 s, total=269.904 s; sync files=12254, longest=0.010 s, average=0.001 s; distance=305864 kB, estimate=305864 kB; lsn=44B/E7AC9BE0, redo lsn=44B/C6AB2658
2026-01-26 19:17:05 UTC::@:[1337]:LOG:  checkpoint starting: time
2026-01-26 19:17:18 UTC:10.0.3.250(41642):postgres@pgstac:[2724]:LOG:  could not send data to client: Broken pipe
2026-01-26 19:17:18 UTC:10.0.3.250(41642):postgres@pgstac:[2724]:FATAL:  connection to client lost
2026-01-26 19:17:18 UTC::@:[2780]:LOG:  automatic vacuum of table "pgstac.pgstac.partition_stats": index scans: 1
	pages: 0 removed, 51 remain, 51 scanned (100.00% of total)
	tuples: 733 removed, 852 remain, 0 are dead but not yet removable
	removable cutoff: 277249, which was 4 XIDs old when operation ended
	frozen: 0 pages from table (0.00% of total) had 0 tuples frozen
	index scan needed: 25 pages from table (49.02% of total) had 761 dead item identifiers removed
	index "partition_stats_pkey": pages: 9 in total, 0 newly deleted, 0 currently deleted, 0 reusable
	index "partitions_range_idx": pages: 18 in total, 0 newly deleted, 1 currently deleted, 1 reusable
	I/O timings: read: 0.645 ms, write: 0.000 ms
	avg read rate: 0.000 MB/s, avg write rate: 0.000 MB/s
	buffer usage: 218 hits, 1 misses, 4 dirtied
	WAL usage: 117 records, 5 full page images, 16494 bytes
	system usage: CPU: user: 0.00 s, system: 0.00 s, elapsed: 187.63 s
2026-01-26 19:17:18 UTC::@:[2765]:LOG:  automatic vacuum of table "pgstac.pg_catalog.pg_class": index scans: 1
	pages: 0 removed, 1311 remain, 1311 scanned (100.00% of total)
	tuples: 258 removed, 5619 remain, 0 are dead but not yet removable
	removable cutoff: 277249, which was 5 XIDs old when operation ended
	frozen: 0 pages from table (0.00% of total) had 0 tuples frozen
	index scan needed: 788 pages from table (60.11% of total) had 16360 dead item identifiers removed
	index "pg_class_oid_index": pages: 171 in total, 28 newly deleted, 83 currently deleted, 55 reusable
	index "pg_class_relname_nsp_index": pages: 380 in total, 34 newly deleted, 107 currently deleted, 73 reusable
	index "pg_class_tblspc_relfilenode_index": pages: 302 in total, 29 newly deleted, 88 currently deleted, 59 reusable
	I/O timings: read: 58.412 ms, write: 0.127 ms
	avg read rate: 0.014 MB/s, avg write rate: 0.031 MB/s
	buffer usage: 4830 hits, 371 misses, 798 dirtied
	WAL usage: 2103 records, 1068 full page images, 456861 bytes
	system usage: CPU: user: 0.05 s, system: 0.01 s, elapsed: 203.02 s
2026-01-26 19:20:53 UTC:10.0.3.250(11905):postgres@pgstac:[2923]:LOG:  could not send data to client: Broken pipe
2026-01-26 19:20:53 UTC:10.0.3.250(11905):postgres@pgstac:[2923]:FATAL:  connection to client lost
2026-01-26 19:20:53 UTC::@:[2765]:LOG:  automatic vacuum of table "pgstac.pgstac.partition_stats": index scans: 1
	pages: 0 removed, 51 remain, 51 scanned (100.00% of total)
	tuples: 733 removed, 852 remain, 0 are dead but not yet removable
	removable cutoff: 277253, which was 6 XIDs old when operation ended
	frozen: 0 pages from table (0.00% of total) had 0 tuples frozen
	index scan needed: 26 pages from table (50.98% of total) had 761 dead item identifiers removed
	index "partition_stats_pkey": pages: 9 in total, 0 newly deleted, 0 currently deleted, 0 reusable
	index "partitions_range_idx": pages: 18 in total, 2 newly deleted, 2 currently deleted, 0 reusable
	I/O timings: read: 0.000 ms, write: 0.000 ms
	avg read rate: 0.000 MB/s, avg write rate: 0.000 MB/s
	buffer usage: 219 hits, 0 misses, 0 dirtied
	WAL usage: 124 records, 40 full page images, 27125 bytes
	system usage: CPU: user: 0.00 s, system: 0.00 s, elapsed: 214.68 s
2026-01-26 19:20:53 UTC::@:[2941]:LOG:  automatic vacuum of table "pgstac.pgstac.cql2_ops": index scans: 0
	pages: 0 removed, 1 remain, 1 scanned (100.00% of total)
	tuples: 58 removed, 29 remain, 0 are dead but not yet removable
	removable cutoff: 277253, which was 6 XIDs old when operation ended
	new relfrozenxid: 277253, which is 54 XIDs ahead of previous value
	frozen: 0 pages from table (0.00% of total) had 0 tuples frozen
	index scan not needed: 0 pages from table (0.00% of total) had 0 dead item identifiers removed
	I/O timings: read: 2.028 ms, write: 0.000 ms
	avg read rate: 0.000 MB/s, avg write rate: 0.000 MB/s
	buffer usage: 33 hits, 4 misses, 3 dirtied
	WAL usage: 5 records, 3 full page images, 864 bytes
	system usage: CPU: user: 0.00 s, system: 0.00 s, elapsed: 207.23 s
2026-01-26 19:21:35 UTC::@:[1337]:LOG:  checkpoint complete: wrote 4402 buffers (6.7%); 0 WAL file(s) added, 0 removed, 8 recycled; write=269.644 s, sync=0.055 s, total=269.787 s; sync files=7945, longest=0.001 s, average=0.001 s; distance=595913 kB, estimate=595913 kB; lsn=44C/70987F0, redo lsn=44B/EB0A4B78

----------------------- END OF LOG ----------------------
```