### PR TITLE
deps: upgrade to eoapi-cdk 11.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "aws-cdk-lib": "^2.220.0",
         "constructs": "^10.3.0",
-        "eoapi-cdk": "^11.1.2",
+        "eoapi-cdk": "^11.2.0",
         "source-map-support": "^0.5.16"
       },
       "bin": {
@@ -2544,9 +2544,9 @@
       "license": "MIT"
     },
     "node_modules/eoapi-cdk": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/eoapi-cdk/-/eoapi-cdk-11.1.2.tgz",
-      "integrity": "sha512-w2gLB4MtO3TH2tqnzMpoXOBe3cMENPP5JiSVX9Pm3OVJAXkHYg1EVNMvoYHJ8yifYvj3yA6MKLhQarbJsppOtA==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/eoapi-cdk/-/eoapi-cdk-11.2.0.tgz",
+      "integrity": "sha512-uD6oK+W9oqtrwcL4wBDDtg7G4AOdbUqD+hzUCFk/ZsI5jlwRy9HW049aN/M3lbsvW5TtuBRQ6ccLhjNne9Yv5g==",
       "license": "ISC",
       "peerDependencies": {
         "aws-cdk-lib": "^2.220.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "aws-cdk-lib": "^2.220.0",
     "constructs": "^10.3.0",
-    "eoapi-cdk": "^11.1.2",
+    "eoapi-cdk": "^11.2.0",
     "source-map-support": "^0.5.16"
   }
 }


### PR DESCRIPTION
This upgrades our STAC API runtime, some recent fixes for stac-loader, pgbouncer healthcheck, and the new PatchManager feature in pgbouncer.