### PR TITLE
fix: add small delivery delay and space out retries

### DIFF
--- a/cdk/constructs/DpsStacItemGenerator/index.ts
+++ b/cdk/constructs/DpsStacItemGenerator/index.ts
@@ -162,7 +162,8 @@ export class DpsStacItemGenerator extends Construct {
 
     // Create main queue
     this.queue = new sqs.Queue(this, "Queue", {
-      visibilityTimeout: Duration.seconds(timeoutSeconds + 10),
+      deliveryDelay: Duration.minutes(1),
+      visibilityTimeout: Duration.minutes(5),
       encryption: sqs.QueueEncryption.SQS_MANAGED,
       deadLetterQueue: {
         maxReceiveCount: 5,


### PR DESCRIPTION
This will help avoid the DPS stage out race condition between the catalog.json uploads and any associated STAC items.

resolves #83