### PR TITLE
fix: untangle dependency between PatchManager and PgstacInfra stacks

### DIFF
--- a/cdk/PatchManager.ts
+++ b/cdk/PatchManager.ts
@@ -38,7 +38,7 @@ export class PatchManagerStack extends Stack {
     );
 
     const instanceIds = props.pgbouncerParamNames.map((paramName) =>
-      ssm.StringParameter.valueFromLookup(this, paramName)
+      ssm.StringParameter.valueForStringParameter(this, paramName)
     );
 
     // Target EC2 instances by Name tag

--- a/cdk/PatchManager.ts
+++ b/cdk/PatchManager.ts
@@ -37,6 +37,10 @@ export class PatchManagerStack extends Stack {
       },
     );
 
+    const instanceIds = props.pgbouncerParamNames.map((paramName) =>
+      ssm.StringParameter.valueFromLookup(this, paramName)
+    );
+
     // Target EC2 instances by Name tag
     const target = new ssm.CfnMaintenanceWindowTarget(
       this,
@@ -47,7 +51,7 @@ export class PatchManagerStack extends Stack {
         targets: [
           {
             key: 'InstanceIds',
-            values: [...props.instanceIds],
+            values: instanceIds,
           },
         ],
       },
@@ -81,7 +85,7 @@ export class PatchManagerStack extends Stack {
 
 export interface Props extends StackProps {
   /**
-   * Instance IDs to target for patching.
+   * SSM parameter names storing the PgBouncer EC2 instance IDs to target for patching.
    */
-  instanceIds: string[];
+  pgbouncerParamNames: string[];
 }

--- a/cdk/PgStacInfra.ts
+++ b/cdk/PgStacInfra.ts
@@ -9,6 +9,7 @@ import {
   aws_cloudfront as cloudfront,
   aws_cloudfront_origins as origins,
   aws_cloudwatch as cloudwatch,
+  aws_ssm as ssm,
 } from "aws-cdk-lib";
 import { Aws, Duration, RemovalPolicy, Stack, StackProps } from "aws-cdk-lib";
 import { Construct } from "constructs";
@@ -27,7 +28,6 @@ import { load } from "js-yaml";
 import { DpsStacItemGenerator } from "./constructs/DpsStacItemGenerator";
 
 export class PgStacInfra extends Stack {
-  public readonly pgbouncerInstanceId: string;
   constructor(scope: Construct, id: string, props: Props) {
     super(scope, id, props);
 
@@ -71,7 +71,11 @@ export class PgStacInfra extends Stack {
       bootstrapperLambdaFunctionOptions: { timeout: Duration.minutes(15) },
     });
     if (pgstacDb.pgbouncerInstanceId) {
-      this.pgbouncerInstanceId = pgstacDb.pgbouncerInstanceId;
+      new ssm.StringParameter(this, "pgbouncer-instance-id-param", {
+        parameterName: `/maap-eoapi/${stage}/${type}/pgbouncer-instance-id`,
+        stringValue: pgstacDb.pgbouncerInstanceId,
+        description: `PgBouncer EC2 instance ID for MAAP eoAPI ${type} stack (${stage})`,
+      });
     }
 
     const apiSubnetSelection: ec2.SubnetSelection = {

--- a/cdk/app.ts
+++ b/cdk/app.ts
@@ -130,9 +130,9 @@ const userInfrastructure = new PgStacInfra(app, buildStackName("userSTAC"), {
 });
 
 new PatchManagerStack(app, buildStackName("patch-manager"), {
-  instanceIds: [
-    coreInfrastructure.pgbouncerInstanceId,
-    userInfrastructure.pgbouncerInstanceId,
+  pgbouncerParamNames: [
+    `/maap-eoapi/${stage}/public/pgbouncer-instance-id`,
+    `/maap-eoapi/${stage}/internal/pgbouncer-instance-id`,
   ],
   terminationProtection: false,
 });

--- a/cdk/app.ts
+++ b/cdk/app.ts
@@ -134,5 +134,9 @@ new PatchManagerStack(app, buildStackName("patch-manager"), {
     `/maap-eoapi/${stage}/public/pgbouncer-instance-id`,
     `/maap-eoapi/${stage}/internal/pgbouncer-instance-id`,
   ],
+  env: {
+    account: process.env.CDK_DEFAULT_ACCOUNT,
+    region: process.env.CDK_DEFAULT_REGION,
+  },
   terminationProtection: false,
 });

--- a/cdk/app.ts
+++ b/cdk/app.ts
@@ -134,9 +134,5 @@ new PatchManagerStack(app, buildStackName("patch-manager"), {
     `/maap-eoapi/${stage}/public/pgbouncer-instance-id`,
     `/maap-eoapi/${stage}/internal/pgbouncer-instance-id`,
   ],
-  env: {
-    account: process.env.CDK_DEFAULT_ACCOUNT,
-    region: process.env.CDK_DEFAULT_REGION,
-  },
   terminationProtection: false,
 });

--- a/cdk/app.ts
+++ b/cdk/app.ts
@@ -129,10 +129,12 @@ const userInfrastructure = new PgStacInfra(app, buildStackName("userSTAC"), {
   terminationProtection: false,
 });
 
-new PatchManagerStack(app, buildStackName("patch-manager"), {
+const patchManager = new PatchManagerStack(app, buildStackName("patch-manager"), {
   pgbouncerParamNames: [
     `/maap-eoapi/${stage}/public/pgbouncer-instance-id`,
     `/maap-eoapi/${stage}/internal/pgbouncer-instance-id`,
   ],
   terminationProtection: false,
 });
+patchManager.addDependency(coreInfrastructure);
+patchManager.addDependency(userInfrastructure);

--- a/cdk/dockerfiles/Dockerfile.raster
+++ b/cdk/dockerfiles/Dockerfile.raster
@@ -1,7 +1,7 @@
 ARG PYTHON_VERSION=3.12
 
 FROM --platform=linux/amd64 public.ecr.aws/lambda/python:${PYTHON_VERSION}
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.10.9 /uv /uvx /bin/
 
 # Install system dependencies to compile (numexpr)
 RUN dnf install -y gcc-c++

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "aws-cdk-lib": "^2.220.0",
         "constructs": "^10.3.0",
-        "eoapi-cdk": "^11.2.0",
+        "eoapi-cdk": "^11.3.0",
         "source-map-support": "^0.5.16"
       },
       "bin": {
@@ -2544,9 +2544,9 @@
       "license": "MIT"
     },
     "node_modules/eoapi-cdk": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/eoapi-cdk/-/eoapi-cdk-11.2.0.tgz",
-      "integrity": "sha512-uD6oK+W9oqtrwcL4wBDDtg7G4AOdbUqD+hzUCFk/ZsI5jlwRy9HW049aN/M3lbsvW5TtuBRQ6ccLhjNne9Yv5g==",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/eoapi-cdk/-/eoapi-cdk-11.3.0.tgz",
+      "integrity": "sha512-tTVvSC/56IN68MltobbgfYi6hVbxSAt206wi2kpBgX8VakoH1BgnH99KE9JsdSmXCya58Tfjw9r4C0UJifibXA==",
       "license": "ISC",
       "peerDependencies": {
         "aws-cdk-lib": "^2.220.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "aws-cdk-lib": "^2.220.0",
     "constructs": "^10.3.0",
-    "eoapi-cdk": "^11.2.0",
+    "eoapi-cdk": "^11.3.0",
     "source-map-support": "^0.5.16"
   }
 }


### PR DESCRIPTION
I think I created this snarl by suggesting we pipe the instance ids from PgstacInfra into the PatchManger construct :disappointed: 

It will require manually deleting the PatchManager stacks to break the dependency that is blocking updates to the PgstacInfra stacks.
