### PR TITLE
feat: enable auto collection extent updates

### DIFF
--- a/cdk/PgStacInfra.ts
+++ b/cdk/PgStacInfra.ts
@@ -67,8 +67,13 @@ export class PgStacInfra extends Stack {
       addPgbouncer: true,
       addPatchManager: false,
       pgstacVersion: pgstacDbConfig.pgstacVersion,
-      customResourceProperties: { context: true },
+      customResourceProperties: {
+        context: true,
+        update_collection_extent: true,
+        use_queue: true,
+      },
       bootstrapperLambdaFunctionOptions: { timeout: Duration.minutes(15) },
+      parameters: { shared_preload_libraries: "pg_cron" },
     });
     if (pgstacDb.pgbouncerInstanceId) {
       new ssm.StringParameter(this, "pgbouncer-instance-id-param", {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "ts_app",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ts_app",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "aws-cdk-lib": "^2.220.0",
         "constructs": "^10.3.0",
-        "eoapi-cdk": "^11.3.1",
+        "eoapi-cdk": "^11.5.0",
         "source-map-support": "^0.5.16"
       },
       "bin": {
@@ -2544,9 +2544,9 @@
       "license": "MIT"
     },
     "node_modules/eoapi-cdk": {
-      "version": "11.3.1",
-      "resolved": "https://registry.npmjs.org/eoapi-cdk/-/eoapi-cdk-11.3.1.tgz",
-      "integrity": "sha512-gheTpPnGeRr3ec0y3j53gFybnHXsktb4VimEcCVMkyU0e+tvLthJ9Kkmtdksj3KIkE/oO+Bh0WEnlvEN8u0mgg==",
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/eoapi-cdk/-/eoapi-cdk-11.5.0.tgz",
+      "integrity": "sha512-Uzlb/URd66nqyYkf1xdvlh6+4mx5/VcSrPlF9uAJ64Og5pqp7/E9NPfcW5UWMXjpVjTE3Q3cgRXcOi3jdZxXvA==",
       "license": "ISC",
       "peerDependencies": {
         "aws-cdk-lib": "^2.220.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "aws-cdk-lib": "^2.220.0",
     "constructs": "^10.3.0",
-    "eoapi-cdk": "^11.3.1",
+    "eoapi-cdk": "^11.5.0",
     "source-map-support": "^0.5.16"
   }
 }


### PR DESCRIPTION
This will be really helpful in the User STAC because most collections just get a boiler plate global extent. With this change, a cron job will run on the pgstac database to update the collection extent to match the full extent of the items in the collection.